### PR TITLE
Add support for `Warning` result summaries

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <VersionMajor Condition="'$(VersionMajor)' == ''">1</VersionMajor>
         <VersionMinor Condition="'$(VersionMinor)' == ''">0</VersionMinor>
-        <VersionPatch Condition="'$(VersionPatch)' == ''">2</VersionPatch>
+        <VersionPatch Condition="'$(VersionPatch)' == ''">1</VersionPatch>
         <BuildNumber Condition="'$(BuildNumber)' == ''">24</BuildNumber>
         <VersionSuffix Condition="'$(Configuration)' == 'Debug' and '$(VersionSuffix)' == ''">dev</VersionSuffix>
         <Authors>gfoidl</Authors>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <VersionMajor Condition="'$(VersionMajor)' == ''">1</VersionMajor>
         <VersionMinor Condition="'$(VersionMinor)' == ''">0</VersionMinor>
-        <VersionPatch Condition="'$(VersionPatch)' == ''">1</VersionPatch>
+        <VersionPatch Condition="'$(VersionPatch)' == ''">2</VersionPatch>
         <BuildNumber Condition="'$(BuildNumber)' == ''">24</BuildNumber>
         <VersionSuffix Condition="'$(Configuration)' == 'Debug' and '$(VersionSuffix)' == ''">dev</VersionSuffix>
         <Authors>gfoidl</Authors>

--- a/source/trx2junit/Models/Outcome.cs
+++ b/source/trx2junit/Models/Outcome.cs
@@ -5,6 +5,7 @@
         Passed,
         Failed,
         NotExecuted,
-        Completed
+        Completed,
+        Warning
     }
 }

--- a/tests/trx2junit.Tests/Internal/TrxParserTests/Parse.cs
+++ b/tests/trx2junit.Tests/Internal/TrxParserTests/Parse.cs
@@ -23,7 +23,7 @@ namespace trx2junit.Tests.Internal.TrxParserTests
         }
 
         [Test]
-        public void Parse_MsTestWithWarnings___OK()
+        public void Parse_MsTest_with_warnings___OK()
         {
             Models.Test actual = this.ParseCore("./data/mstest-warning.trx");
 

--- a/tests/trx2junit.Tests/Internal/TrxParserTests/Parse.cs
+++ b/tests/trx2junit.Tests/Internal/TrxParserTests/Parse.cs
@@ -21,6 +21,14 @@ namespace trx2junit.Tests.Internal.TrxParserTests
 
             Assert.IsNotNull(actual);
         }
+
+        [Test]
+        public void Parse_MsTestWithWarnings___OK()
+        {
+            Models.Test actual = this.ParseCore("./data/mstest-warning.trx");
+
+            Assert.IsNotNull(actual);
+        }
         //---------------------------------------------------------------------
         private Models.Test ParseCore(string fileName)
         {

--- a/tests/trx2junit.Tests/data/mstest-warning.trx
+++ b/tests/trx2junit.Tests/data/mstest-warning.trx
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestRun id="e3441463-34d0-4de4-a23f-3c0550129788" name="build-user@BUILD-HOST 2018-09-04 08:42:36" runUser="DOMAIN\build-user" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+  <TestSettings name="Default Test Settings" id="667d87a0-ed7f-4b11-971a-e77cb7312747">
+    <Deployment userDeploymentRoot="C:\builds\74762f22\0\Project\TestResults" useDefaultDeploymentRoot="false" runDeploymentRoot="build-user_BUILD-HOST 2018-09-04 08_42_36" />
+    <Execution>
+      <TestTypeSpecific />
+      <AgentRule name="Execution Agents">
+      </AgentRule>
+    </Execution>
+    <Properties />
+  </TestSettings>
+  <Times creation="2018-09-04T08:42:36.7423528-04:00" queuing="2018-09-04T08:42:59.7678324-04:00" start="2018-09-04T08:43:00.1718583-04:00" finish="2018-09-04T08:43:23.8963828-04:00" />
+  <ResultSummary outcome="Warning">
+    <Counters total="1" executed="1" passed="1" error="0" failed="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
+    <RunInfos>
+      <RunInfo computerName="BUILD-HOST" outcome="Warning" timestamp="2018-09-04T08:42:59.7018271-04:00">
+        <Text>Warning: Test Run deployment issue: The assembly or module 'Some.Random.Thing' directly or indirectly referenced by the test container 'c:\builds\74762f22\0\Project\bin\release\project.dll' was not found.</Text>
+      </RunInfo>
+    </RunInfos>
+  </ResultSummary>
+  <TestDefinitions>
+    <UnitTest name="MyTest" storage="c:\builds\74762f22\0\project\bin\release\project.dll" id="2f883222-b158-daea-c5b3-ffe008e58ebe">
+      <TestCategory>
+        <TestCategoryItem TestCategory="Small" />
+      </TestCategory>
+      <Execution id="32a33de7-5939-43f5-9635-d11d114395ad" />
+      <TestMethod codeBase="C:/builds/74762f22/0/project/bin/Release/project.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Project.TestClass, Project, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="MyTest" />
+    </UnitTest>
+  </TestDefinitions>
+  <TestLists>
+    <TestList name="Results Not in a List" id="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestList name="All Loaded Results" id="19431567-8539-422a-85d7-44ee4e166bda" />
+  </TestLists>
+  <TestEntries>
+    <TestEntry testId="2f883222-b158-daea-c5b3-ffe008e58ebe" executionId="32a33de7-5939-43f5-9635-d11d114395ad" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+  </TestEntries>
+  <Results>
+    <UnitTestResult executionId="32a33de7-5939-43f5-9635-d11d114395ad" testId="2f883222-b158-daea-c5b3-ffe008e58ebe" testName="MyTest" computerName="BUILD-HOST" duration="00:00:00.0038088" startTime="2018-09-04T08:43:05.5582037-04:00" endTime="2018-09-04T08:43:05.5642039-04:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="32a33de7-5939-43f5-9635-d11d114395ad">
+    </UnitTestResult>
+  </Results>
+</TestRun>


### PR DESCRIPTION
* cover less well-behaved mstest results
* new test TRX file with names changed to protect the innocent
* patch version bump, assuming this project follows semver

refs #12