### PR TITLE
Allows the file to be in PWD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,28 @@ jobs:
                     ./verify-xml.sh "TestResults/nunit.xml"
                     ./verify-xml.sh "TestResults/mstest.xml"
             - run:
+                name: run-single-arg
+                command: |
+                    mkdir ./single-arg
+                    cp tests/trx2junit.Tests/data/nunit.trx ./single-arg
+
+                    echo "-----------------------------------------------"
+                    echo "file in different location than pwd"
+                    trx2junit ./single-arg/nunit.trx
+
+                    echo ""
+                    ./verify-xml.sh "single-arg/nunit.xml"
+
+                    echo ""
+                    echo "-----------------------------------------------"
+                    echo "file in same location than pwd"
+                    cd single-arg
+                    trx2junit nunit.trx
+
+                    echo ""
+                    cd -
+                    ./verify-xml.sh "single-arg/nunit.xml"
+            - run:
                 name: run-multiple-args
                 command: |
                     mkdir ./multiple-args

--- a/source/trx2junit/Worker.cs
+++ b/source/trx2junit/Worker.cs
@@ -58,7 +58,9 @@ namespace trx2junit
         private static void EnsureOutputDirectoryExists(string jUnitFile)
         {
             string directory = Path.GetDirectoryName(jUnitFile);
-            Directory.CreateDirectory(directory);
+
+            if (!string.IsNullOrWhiteSpace(directory))
+                Directory.CreateDirectory(directory);
         }
     }
 }

--- a/tests/trx2junit.Tests/WorkerTests/RunAsync/LocationIsPwd.cs
+++ b/tests/trx2junit.Tests/WorkerTests/RunAsync/LocationIsPwd.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace trx2junit.Tests.WorkerTests.RunAsync
+{
+    [TestFixture]
+    public class LocationIsPwd
+    {
+        private string _curDir;
+        //---------------------------------------------------------------------
+        [SetUp]
+        public void SetUp()
+        {
+            _curDir = Environment.CurrentDirectory;
+            Environment.CurrentDirectory = "./data";
+        }
+        //---------------------------------------------------------------------
+        [TearDown]
+        public void TearDown()
+        {
+            Environment.CurrentDirectory = _curDir;
+        }
+        //---------------------------------------------------------------------
+        [Test]
+        public async Task Single_file_given___converted()
+        {
+            string[] expectedFiles = { "nunit.xml" };
+            DeleteExpectedFiles(expectedFiles);
+
+            var sut = new Worker();
+
+            string[] args = { "nunit.trx" };
+            var options   = new WorkerOptions(args);
+            await sut.RunAsync(options);
+
+            CheckExpectedFilesExist(expectedFiles);
+        }
+        //---------------------------------------------------------------------
+        [Test]
+        public async Task Multiple_files_given___converted()
+        {
+            string[] expectedFiles = { "nunit.xml", "mstest.xml", "mstest-warning.xml" };
+            DeleteExpectedFiles(expectedFiles);
+
+            var sut = new Worker();
+
+            string[] args = { "nunit.trx", "mstest.trx", "mstest-warning.trx" };
+            var options   = new WorkerOptions(args);
+            await sut.RunAsync(options);
+
+            CheckExpectedFilesExist(expectedFiles);
+        }
+        //---------------------------------------------------------------------
+        private static void DeleteExpectedFiles(string[] files)
+        {
+            foreach (string file in files)
+                File.Delete(file);
+        }
+        //---------------------------------------------------------------------
+        private static void CheckExpectedFilesExist(string[] files)
+        {
+            Assert.Multiple(() =>
+            {
+                foreach (string file in files)
+                {
+                    bool actual = File.Exists(file);
+                    Assert.IsTrue(actual, $"File '{file}' does not exist");
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
So far it was assumed that the files reside in a location different to `$PWD`.
When calling with `trx2junit foo.trx` the directory is an empty string, hence trying to create the directory throws 
```
System.ArgumentException : Path cannot be the empty string or all whitespace.
Parameter name: path
```

Fixes https://github.com/gfoidl/trx2junit/issues/26