### PR TITLE
trx to junit keeps stdout per testcase

### DIFF
--- a/schemas/jenkins-junit.xsd
+++ b/schemas/jenkins-junit.xsd
@@ -45,7 +45,7 @@
     <xs:element name="properties">
         <xs:complexType>
             <xs:sequence>
-                <xs:element ref="property" maxOccurs="unbounded"/>
+                <xs:element ref="property" minOccurs="0" maxOccurs="unbounded"/>
             </xs:sequence>
         </xs:complexType>
     </xs:element>

--- a/source/trx2junit/Internal/trx2junit/JUnitTestResultXmlBuilder.cs
+++ b/source/trx2junit/Internal/trx2junit/JUnitTestResultXmlBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text;
 using System.Xml.Linq;
 using trx2junit.Models;
@@ -95,12 +95,16 @@ namespace trx2junit
 
             if (testCase.SystemErr != null)
             {
+                xTestCase.Add(new XElement("system-err", testCase.SystemErr));
+
                 _junitTestSuiteSystemErrStringBuilder ??= new StringBuilder();
                 _junitTestSuiteSystemErrStringBuilder.AppendLine(testCase.SystemErr);
             }
 
             if (testCase.SystemOut != null)
             {
+                xTestCase.Add(new XElement("system-out", testCase.SystemOut));
+
                 _junitTestSuiteSystemOutStringBuilder ??= new StringBuilder();
                 _junitTestSuiteSystemOutStringBuilder.AppendLine(testCase.SystemOut);
             }

--- a/source/trx2junit/Internal/trx2junit/Trx2JunitTestConverter.cs
+++ b/source/trx2junit/Internal/trx2junit/Trx2JunitTestConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/tests/scripts/run-different-output-location.sh
+++ b/tests/scripts/run-different-output-location.sh
@@ -7,5 +7,5 @@ echo ""
 trx2junit --output ./tests/junit-out ./different-output-location/mstest.trx ./different-output-location/nunit.trx
 
 echo ""
-./verify-xml.sh "schemas/junit.xsd" "tests/junit-out/mstest.xml"
-./verify-xml.sh "schemas/junit.xsd" "tests/junit-out/nunit.xml"
+./verify-xml.sh "schemas/jenkins-junit.xsd" "tests/junit-out/mstest.xml"
+./verify-xml.sh "schemas/jenkins-junit.xsd" "tests/junit-out/nunit.xml"

--- a/tests/scripts/run-globbing.sh
+++ b/tests/scripts/run-globbing.sh
@@ -9,7 +9,7 @@ trx2junit ./globbing/*.trx
 echo ""
 
 for junit in ./globbing/*.xml; do
-    ./verify-xml.sh "schemas/junit.xsd" "$junit"
+    ./verify-xml.sh "schemas/jenkins-junit.xsd" "$junit"
 done
 
 nTrx=$(ls -l ./globbing/*.trx | wc -l)

--- a/tests/scripts/run-multiple-args.sh
+++ b/tests/scripts/run-multiple-args.sh
@@ -7,6 +7,6 @@ echo ""
 trx2junit ./multiple-args/mstest.trx ./multiple-args/mstest-warning.trx ./multiple-args/nunit.trx
 
 echo ""
-./verify-xml.sh "schemas/junit.xsd" "multiple-args/mstest.xml"
-./verify-xml.sh "schemas/junit.xsd" "multiple-args/mstest-warning.xml"
-./verify-xml.sh "schemas/junit.xsd" "multiple-args/nunit.xml"
+./verify-xml.sh "schemas/jenkins-junit.xsd" "multiple-args/mstest.xml"
+./verify-xml.sh "schemas/jenkins-junit.xsd" "multiple-args/mstest-warning.xml"
+./verify-xml.sh "schemas/jenkins-junit.xsd" "multiple-args/nunit.xml"

--- a/tests/scripts/run-no-globbing.sh
+++ b/tests/scripts/run-no-globbing.sh
@@ -11,7 +11,7 @@ set +f
 echo ""
 
 for junit in ./no-globbing/*.xml; do
-    ./verify-xml.sh "schemas/junit.xsd" "$junit"
+    ./verify-xml.sh "schemas/jenkins-junit.xsd" "$junit"
 done
 
 nTrx=$(ls -l ./no-globbing/*.trx | wc -l)

--- a/tests/scripts/run-samples.sh
+++ b/tests/scripts/run-samples.sh
@@ -20,6 +20,6 @@ trx2junit ./TestResults/mstest.trx
 trx2junit ./TestResults/xunit.trx
 
 echo ""
-./verify-xml.sh "schemas/junit.xsd" "TestResults/nunit.xml"
-./verify-xml.sh "schemas/junit.xsd" "TestResults/mstest.xml"
-./verify-xml.sh "schemas/junit.xsd" "TestResults/xunit.xml"
+./verify-xml.sh "schemas/jenkins-junit.xsd" "TestResults/nunit.xml"
+./verify-xml.sh "schemas/jenkins-junit.xsd" "TestResults/mstest.xml"
+./verify-xml.sh "schemas/jenkins-junit.xsd" "TestResults/xunit.xml"

--- a/tests/scripts/run-single-arg.sh
+++ b/tests/scripts/run-single-arg.sh
@@ -18,4 +18,4 @@ trx2junit nunit.trx
 
 echo ""
 cd -
-./verify-xml.sh "schemas/junit.xsd" "single-arg/nunit.xml"
+./verify-xml.sh "schemas/jenkins-junit.xsd" "single-arg/nunit.xml"

--- a/tests/trx2junit.Tests/Internal/JUnitTestResultXmlBuilderTests/Integration.cs
+++ b/tests/trx2junit.Tests/Internal/JUnitTestResultXmlBuilderTests/Integration.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Xml.Linq;
 using NUnit.Framework;
 
@@ -62,6 +62,30 @@ namespace trx2junit.Tests.Internal.JUnitTestResultXmlBuilderTests
 
             XElement testsuite = sut.Result.Elements("testsuite").First();
             XElement systemOut = testsuite.Element("system-out");
+
+            Assert.IsNotNull(systemOut, nameof(systemOut));
+            Assert.AreEqual("message written to stdout", systemOut.Value);
+        }
+        //---------------------------------------------------------------------
+        [Test]
+        public void TrxUnitTestResult_with_stdout___system_out_set_by_testcase()
+        {
+            XElement trx = XElement.Load("./data/trx/nunit-with-stdout.trx");
+            var parser   = new TrxTestResultXmlParser(trx);
+
+            parser.Parse();
+            Models.TrxTest testData = parser.Result;
+
+            var converter = new Trx2JunitTestConverter(testData);
+            converter.Convert();
+
+            Models.JUnitTest junitTest = converter.Result;
+            var sut                    = new JUnitTestResultXmlBuilder(junitTest);
+            sut.Build();
+
+            XElement testsuite = sut.Result.Elements("testsuite").First();
+            XElement testcase  = testsuite.Elements("testcase").First();
+            XElement systemOut = testcase.Element("system-out");
 
             Assert.IsNotNull(systemOut, nameof(systemOut));
             Assert.AreEqual("message written to stdout", systemOut.Value);

--- a/tests/trx2junit.Tests/Internal/JUnitTestResultXmlBuilderTests/Integration.cs
+++ b/tests/trx2junit.Tests/Internal/JUnitTestResultXmlBuilderTests/Integration.cs
@@ -90,5 +90,52 @@ namespace trx2junit.Tests.Internal.JUnitTestResultXmlBuilderTests
             Assert.IsNotNull(systemOut, nameof(systemOut));
             Assert.AreEqual("message written to stdout", systemOut.Value);
         }
+        //---------------------------------------------------------------------
+        [Test]
+        public void TrxUnitTestResult_with_stderr___system_err_set()
+        {
+            XElement trx = XElement.Load("./data/trx/nunit-with-stderr.trx");
+            var parser   = new TrxTestResultXmlParser(trx);
+
+            parser.Parse();
+            Models.TrxTest testData = parser.Result;
+
+            var converter = new Trx2JunitTestConverter(testData);
+            converter.Convert();
+
+            Models.JUnitTest junitTest = converter.Result;
+            var sut                    = new JUnitTestResultXmlBuilder(junitTest);
+            sut.Build();
+
+            XElement testsuite = sut.Result.Elements("testsuite").First();
+            XElement systemErr = testsuite.Element("system-err");
+
+            Assert.IsNotNull(systemErr, nameof(systemErr));
+            Assert.AreEqual("message written to stderr", systemErr.Value);
+        }
+        //---------------------------------------------------------------------
+        [Test]
+        public void TrxUnitTestResult_with_stderr___system_err_set_by_testcase()
+        {
+            XElement trx = XElement.Load("./data/trx/nunit-with-stderr.trx");
+            var parser   = new TrxTestResultXmlParser(trx);
+
+            parser.Parse();
+            Models.TrxTest testData = parser.Result;
+
+            var converter = new Trx2JunitTestConverter(testData);
+            converter.Convert();
+
+            Models.JUnitTest junitTest = converter.Result;
+            var sut                    = new JUnitTestResultXmlBuilder(junitTest);
+            sut.Build();
+
+            XElement testsuite = sut.Result.Elements("testsuite").First();
+            XElement testcase  = testsuite.Elements("testcase").First();
+            XElement systemErr = testcase.Element("system-err");
+
+            Assert.IsNotNull(systemErr, nameof(systemErr));
+            Assert.AreEqual("message written to stderr", systemErr.Value);
+        }
     }
 }

--- a/tests/trx2junit.Tests/ValidationHelper.cs
+++ b/tests/trx2junit.Tests/ValidationHelper.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Xml;
 using System.Xml.Linq;
 using System.Xml.Schema;
@@ -8,7 +8,7 @@ namespace trx2junit.Tests
 {
     internal static class ValidationHelper
     {
-        private static readonly XmlSchemaSet s_schemaJunit = LoadSchema("./data/junit.xsd");
+        private static readonly XmlSchemaSet s_schemaJunit = LoadSchema("./data/jenkins-junit.xsd");
         private static readonly XmlSchemaSet s_schemaTrx   = LoadSchema("./data/vstst.xsd", targetNamespace: "http://microsoft.com/schemas/VisualStudio/TeamTest/2010");
         //---------------------------------------------------------------------
         public static void IsXmlValidJunit(string fileName, bool validateJunit)

--- a/tests/trx2junit.Tests/data/trx/nunit-with-stderr.trx
+++ b/tests/trx2junit.Tests/data/trx/nunit-with-stderr.trx
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TestRun id="74d2c02a-4d28-4c4b-a6f4-a6e2ff0adb9e" name="@b1c9b4be3f08 2018-07-10 10:16:56" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+    <Times creation="2018-07-10T10:16:56.6460518+00:00" queuing="2018-07-10T10:16:56.6460644+00:00" start="2018-07-10T10:16:54.3977331+00:00" finish="2018-07-10T10:16:56.6722455+00:00" />
+    <TestSettings name="default" id="8ee21b83-5b10-4ce6-8e86-6f6629904b2b">
+        <Deployment runDeploymentRoot="_b1c9b4be3f08_2018-07-10_10_16_56" />
+    </TestSettings>
+    <Results>
+        <UnitTestResult executionId="b38409e9-177b-49a2-aed3-c49363ce2f08" testId="9938e175-680b-4783-ae44-17edffa3471e" testName="Passing_test" computerName="b1c9b4be3f08" duration="00:00:00.0010000" startTime="2018-07-10T10:16:55.0000000+00:00" endTime="2018-07-10T10:16:55.0000000+00:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="b38409e9-177b-49a2-aed3-c49363ce2f08">
+            <Output>
+                <StdErr>message written to stderr</StdErr>
+            </Output>
+        </UnitTestResult>
+    </Results>
+    <TestDefinitions>
+        <UnitTest name="Passing_test" storage="/root/repo/samples/nunitsample/bin/release/netcoreapp2.1/nunitsample.dll" id="9938e175-680b-4783-ae44-17edffa3471e">
+            <Execution id="b38409e9-177b-49a2-aed3-c49363ce2f08" />
+            <TestMethod codeBase="/root/repo/samples/NUnitSample/bin/Release/netcoreapp2.1/NUnitSample.dll" adapterTypeName="executor://nunit3testexecutor/" className="SimpleUnitTest.SimpleTests" name="Passing_test" />
+        </UnitTest>
+    </TestDefinitions>
+    <TestEntries>
+        <TestEntry testId="9938e175-680b-4783-ae44-17edffa3471e" executionId="b38409e9-177b-49a2-aed3-c49363ce2f08" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    </TestEntries>
+    <TestLists>
+        <TestList name="Results Not in a List" id="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+        <TestList name="All Loaded Results" id="19431567-8539-422a-85d7-44ee4e166bda" />
+    </TestLists>
+    <ResultSummary outcome="Failed">
+        <Counters total="1" executed="1" passed="1" failed="0" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
+        <Output>
+            <StdOut>NUnit Adapter 3.10.0.21: Test execution startedRunning all tests in /root/repo/samples/NUnitSample/bin/Release/netcoreapp2.1/NUnitSample.dllNUnit3TestExecutor converted 3 of 3 NUnit test casesNUnit Adapter 3.10.0.21: Test execution complete</StdOut>
+        </Output>
+    </ResultSummary>
+</TestRun>


### PR DESCRIPTION
`UnitTestResult.StdOut` is aggregated to `testsuite.system-out` (current behavior) and additionally these messages are emitted to `testcase.system-out`.
`StdErr` / `system-err` is analogous.

Fixes https://github.com/gfoidl/trx2junit/issues/71