### PR TITLE
Jenkins-JUnit emit status attribute for testcase

### DIFF
--- a/.azure/pipelines/jobs/build_and_test.yml
+++ b/.azure/pipelines/jobs/build_and_test.yml
@@ -10,7 +10,8 @@ jobs:
         release-build:
           BUILD_CONFIG: Release
     steps:
-      - template: steps/dotnet-install.yml
+      # Already installed on current hosted agents
+      #- template: steps/dotnet-install.yml
 
       - bash: |
           echo 'installed sdks:'

--- a/.azure/pipelines/jobs/e2e_tests.yml
+++ b/.azure/pipelines/jobs/e2e_tests.yml
@@ -4,7 +4,8 @@ jobs:
     pool:
       vmImage: 'ubuntu-18.04'
     steps:
-      - template: steps/dotnet-install.yml
+      # Already installed on current hosted agents
+      #- template: steps/dotnet-install.yml
 
       - bash: |
           sudo apt update

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,14 +2,14 @@
 
     <PropertyGroup>
         <VersionMajor Condition="'$(VersionMajor)' == ''">1</VersionMajor>
-        <VersionMinor Condition="'$(VersionMinor)' == ''">3</VersionMinor>
-        <VersionPatch Condition="'$(VersionPatch)' == ''">0</VersionPatch>
-        <BuildNumber Condition="'$(BuildNumber)' == ''">88</BuildNumber>
+        <VersionMinor Condition="'$(VersionMinor)' == ''">4</VersionMinor>
+        <VersionPatch Condition="'$(VersionPatch)' == ''">2</VersionPatch>
+        <BuildNumber Condition="'$(BuildNumber)' == ''">102</BuildNumber>
         <VersionSuffix Condition="'$(Configuration)' == 'Debug' and '$(VersionSuffix)' == ''">dev</VersionSuffix>
         <Authors>gfoidl</Authors>
         <Company>Foidl Günther</Company>
         <Product>trx2junit</Product>
-        <Copyright>Copyright © Foidl Günther 2017-2019</Copyright>
+        <Copyright>Copyright © Foidl Günther 2017-2021</Copyright>
         <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionPatch)</VersionPrefix>
         <AssemblyVersion>$(VersionMajor).$(VersionMinor).$(BuildNumber).$(VersionPatch)</AssemblyVersion>
     </PropertyGroup>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2019 Günther Foidl
+Copyright (c) 2017-2021 Günther Foidl
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -43,6 +43,17 @@ $ trx2junit a.trx --output ../results
 $ trx2junit --output results a.trx ../tests/b.trx
 ```
 
+#### Jenkins JUnit
+
+For Jenkins JUnit on the testcase the status-attribute is set. By default `1` is set for success, and `0` for failure.
+This can be configured via environment varialbes (note: if omitted, the default values will be used):
+
+| Status  | Variable                                    | default value |
+|---------|---------------------------------------------|---------------|
+| success | `TRX2JUNIT_JENKINS_TESTCASE_STATUS_SUCCESS` | `1`           |
+| failure | `TRX2JUNIT_JENKINS_TESTCASE_STATUS_FAILURE` | `0`           |
+| skipped | `TRX2JUNIT_JENKINS_TESTCASE_STATUS_SKIPPED` | not set       |
+
 ### junit to trx
 
 With option `--junit2trx` a conversion from _junit_ to _trx_ can be performed.

--- a/source/trx2junit/Globals.cs
+++ b/source/trx2junit/Globals.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace trx2junit
+{
+    internal static class Globals
+    {
+        public static readonly string  JUnitTestCaseStatusSuccess = GetEnvironmentVariable("TRX2JUNIT_JENKINS_TESTCASE_STATUS_SUCCESS") ?? "1";
+        public static readonly string  JUnitTestCaseStatusFailure = GetEnvironmentVariable("TRX2JUNIT_JENKINS_TESTCASE_STATUS_FAILURE") ?? "0";
+        public static readonly string? JUnitTestCaseStatusSkipped = GetEnvironmentVariable("TRX2JUNIT_JENKINS_TESTCASE_STATUS_SKIPPED");
+        //---------------------------------------------------------------------
+        private static string? GetEnvironmentVariable(string envVariableName)
+        {
+            return Environment.GetEnvironmentVariable(envVariableName) // Process
+                ?? Environment.GetEnvironmentVariable(envVariableName, EnvironmentVariableTarget.Machine);
+        }
+    }
+}

--- a/source/trx2junit/Internal/trx2junit/JUnitTestResultXmlBuilder.cs
+++ b/source/trx2junit/Internal/trx2junit/JUnitTestResultXmlBuilder.cs
@@ -83,6 +83,11 @@ namespace trx2junit
             if (testCase.Skipped)
             {
                 xTestCase.Add(new XElement("skipped"));
+
+                if (Globals.JUnitTestCaseStatusSkipped is not null)
+                {
+                    xTestCase.Add(new XAttribute("status", Globals.JUnitTestCaseStatusSkipped));
+                }
             }
             else if (testCase.Error != null)
             {
@@ -92,11 +97,11 @@ namespace trx2junit
                     new XAttribute("type"   , testCase.Error.Type!)
                 ));
 
-                xTestCase.Add(new XAttribute("status", "0"));
+                xTestCase.Add(new XAttribute("status", Globals.JUnitTestCaseStatusFailure));
             }
             else
             {
-                xTestCase.Add(new XAttribute("status", "1"));
+                xTestCase.Add(new XAttribute("status", Globals.JUnitTestCaseStatusSuccess));
             }
 
             if (testCase.SystemErr != null)

--- a/source/trx2junit/Internal/trx2junit/JUnitTestResultXmlBuilder.cs
+++ b/source/trx2junit/Internal/trx2junit/JUnitTestResultXmlBuilder.cs
@@ -91,6 +91,12 @@ namespace trx2junit
                     new XAttribute("message", testCase.Error.Message!),
                     new XAttribute("type"   , testCase.Error.Type!)
                 ));
+
+                xTestCase.Add(new XAttribute("status", "0"));
+            }
+            else
+            {
+                xTestCase.Add(new XAttribute("status", "1"));
             }
 
             if (testCase.SystemErr != null)

--- a/tests/trx2junit.Tests/Internal/JUnitTestResultXmlBuilderTests/Integration.cs
+++ b/tests/trx2junit.Tests/Internal/JUnitTestResultXmlBuilderTests/Integration.cs
@@ -138,5 +138,32 @@ namespace trx2junit.Tests.Internal.JUnitTestResultXmlBuilderTests
             Assert.IsNotNull(systemErr, nameof(systemErr));
             Assert.AreEqual("message written to stderr", systemErr.Value);
         }
+        //---------------------------------------------------------------------
+        [Test]
+        public void Testcase_status_attribute_set()
+        {
+            XElement trx = XElement.Load("./data/trx/nunit.trx");
+            var parser   = new TrxTestResultXmlParser(trx);
+
+            parser.Parse();
+            Models.TrxTest testData = parser.Result;
+
+            var converter = new Trx2JunitTestConverter(testData);
+            converter.Convert();
+
+            Models.JUnitTest junitTest = converter.Result;
+            var sut                    = new JUnitTestResultXmlBuilder(junitTest);
+            sut.Build();
+
+            XElement[] testCases = sut.Result.Descendants("testcase").ToArray();
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(3, testCases.Length);
+                Assert.AreEqual("1", testCases[0].Attribute("status").Value);
+                Assert.AreEqual("0", testCases[1].Attribute("status").Value);
+                Assert.AreEqual("1", testCases[2].Attribute("status").Value);
+            });
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/gfoidl/trx2junit/issues/83

#### Jenkins JUnit

For Jenkins JUnit on the testcase the status-attribute is set. By default `1` is set for success, and `0` for failure.
This can be configured via environment variables (note: if omitted, the default values will be used):

| Status  | Variable                                    | default value |
|---------|---------------------------------------------|---------------|
| success | `TRX2JUNIT_JENKINS_TESTCASE_STATUS_SUCCESS` | `1`           |
| failure | `TRX2JUNIT_JENKINS_TESTCASE_STATUS_FAILURE` | `0`           |
| skipped | `TRX2JUNIT_JENKINS_TESTCASE_STATUS_SKIPPED` | not set       |