### PR TITLE
Optionally emit JUnit testcase (failure) messages to system-err

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2021 Günther Foidl
+Copyright (c) 2017-2022 Günther Foidl
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -54,6 +54,8 @@ This can be configured via environment varialbes (note: if omitted, the default 
 | failure | `TRX2JUNIT_JENKINS_TESTCASE_STATUS_FAILURE` | `0`           |
 | skipped | `TRX2JUNIT_JENKINS_TESTCASE_STATUS_SKIPPED` | not set       |
 
+With the command-line switch `--junit-messages-to-system-out` given the _message attributes_ will be emitted to _system-out_ too.
+
 ### junit to trx
 
 With option `--junit2trx` a conversion from _junit_ to _trx_ can be performed.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -54,7 +54,7 @@ This can be configured via environment varialbes (note: if omitted, the default 
 | failure | `TRX2JUNIT_JENKINS_TESTCASE_STATUS_FAILURE` | `0`           |
 | skipped | `TRX2JUNIT_JENKINS_TESTCASE_STATUS_SKIPPED` | not set       |
 
-With the command-line switch `--junit-messages-to-system-out` given the _message attributes_ will be emitted to _system-out_ too.
+With the command-line switch `--junit-messages-to-system-err` given the _message attributes_ will be emitted to _system-err_ too.
 
 ### junit to trx
 

--- a/source/trx2junit.Core/Internal/trx2junit/JUnitOptions.cs
+++ b/source/trx2junit.Core/Internal/trx2junit/JUnitOptions.cs
@@ -4,13 +4,13 @@ namespace gfoidl.Trx2Junit.Core.Internal;
 
 internal sealed class JUnitOptions
 {
-    public bool JUnitMessagesToSystemOut { get; set; }
+    public bool JUnitMessagesToSystemErr { get; set; }
     //-------------------------------------------------------------------------
     public static JUnitOptions Create(WorkerOptions workerOptions)
     {
         return new JUnitOptions
         {
-            JUnitMessagesToSystemOut = workerOptions.JUnitMessagesToSystemOut
+            JUnitMessagesToSystemErr = workerOptions.JUnitMessagesToSystemErr
         };
     }
 }

--- a/source/trx2junit.Core/Internal/trx2junit/JUnitOptions.cs
+++ b/source/trx2junit.Core/Internal/trx2junit/JUnitOptions.cs
@@ -1,0 +1,16 @@
+// (c) gfoidl, all rights reserved
+
+namespace gfoidl.Trx2Junit.Core.Internal;
+
+internal sealed class JUnitOptions
+{
+    public bool JUnitMessagesToSystemOut { get; set; }
+    //-------------------------------------------------------------------------
+    public static JUnitOptions Create(WorkerOptions workerOptions)
+    {
+        return new JUnitOptions
+        {
+            JUnitMessagesToSystemOut = workerOptions.JUnitMessagesToSystemOut
+        };
+    }
+}

--- a/source/trx2junit.Core/Internal/trx2junit/JUnitTestResultXmlBuilder.cs
+++ b/source/trx2junit.Core/Internal/trx2junit/JUnitTestResultXmlBuilder.cs
@@ -10,16 +10,14 @@ namespace gfoidl.Trx2Junit.Core.Internal;
 
 internal sealed class JUnitTestResultXmlBuilder : ITestResultXmlBuilder<JUnitTest>
 {
-    private readonly JUnitTest    _test;
-    private readonly JUnitOptions _jUnitOptions;
-    private readonly XElement     _xJUnit = new("testsuites");
-    private StringBuilder?        _junitTestSuiteSystemOutStringBuilder;
-    private StringBuilder?        _junitTestSuiteSystemErrStringBuilder;
+    private readonly JUnitTest _test;
+    private readonly XElement  _xJUnit = new("testsuites");
+    private StringBuilder?     _junitTestSuiteSystemOutStringBuilder;
+    private StringBuilder?     _junitTestSuiteSystemErrStringBuilder;
     //-------------------------------------------------------------------------
-    public JUnitTestResultXmlBuilder(JUnitTest test, JUnitOptions options)
+    public JUnitTestResultXmlBuilder(JUnitTest test)
     {
-        _test         = test ?? throw new ArgumentNullException(nameof(test));
-        _jUnitOptions = options;
+        _test = test ?? throw new ArgumentNullException(nameof(test));
     }
     //-------------------------------------------------------------------------
     public JUnitTest Test  => _test;

--- a/source/trx2junit.Core/Internal/trx2junit/JUnitTestResultXmlBuilder.cs
+++ b/source/trx2junit.Core/Internal/trx2junit/JUnitTestResultXmlBuilder.cs
@@ -10,12 +10,17 @@ namespace gfoidl.Trx2Junit.Core.Internal;
 
 internal sealed class JUnitTestResultXmlBuilder : ITestResultXmlBuilder<JUnitTest>
 {
-    private readonly JUnitTest _test;
-    private readonly XElement  _xJUnit = new("testsuites");
-    private StringBuilder?     _junitTestSuiteSystemOutStringBuilder;
-    private StringBuilder?     _junitTestSuiteSystemErrStringBuilder;
+    private readonly JUnitTest    _test;
+    private readonly JUnitOptions _jUnitOptions;
+    private readonly XElement     _xJUnit = new("testsuites");
+    private StringBuilder?        _junitTestSuiteSystemOutStringBuilder;
+    private StringBuilder?        _junitTestSuiteSystemErrStringBuilder;
     //-------------------------------------------------------------------------
-    public JUnitTestResultXmlBuilder(JUnitTest test) => _test = test ?? throw new ArgumentNullException(nameof(test));
+    public JUnitTestResultXmlBuilder(JUnitTest test, JUnitOptions options)
+    {
+        _test         = test ?? throw new ArgumentNullException(nameof(test));
+        _jUnitOptions = options;
+    }
     //-------------------------------------------------------------------------
     public JUnitTest Test  => _test;
     public XElement Result => _xJUnit;

--- a/source/trx2junit.Core/Internal/trx2junit/Trx2JunitTestResultXmlConverter.cs
+++ b/source/trx2junit.Core/Internal/trx2junit/Trx2JunitTestResultXmlConverter.cs
@@ -10,8 +10,12 @@ namespace gfoidl.Trx2Junit.Core.Internal;
 
 internal sealed class Trx2JunitTestResultXmlConverter : TestResultXmlConverter<TrxTest, JUnitTest>
 {
+    private readonly JUnitOptions _jUnitOptions;
+    //-------------------------------------------------------------------------
+    public Trx2JunitTestResultXmlConverter(JUnitOptions jUnitOptions) => _jUnitOptions = jUnitOptions;
+    //-------------------------------------------------------------------------
     protected override Func<XElement, ITestResultXmlParser<TrxTest>> ParserFactory        => testXml => new TrxTestResultXmlParser(testXml);
     protected override Func<TrxTest, ITestConverter<TrxTest, JUnitTest>> ConverterFactory => test    => new Trx2JunitTestConverter(test);
-    protected override Func<JUnitTest, ITestResultXmlBuilder<JUnitTest>> BuilderFactory   => test    => new JUnitTestResultXmlBuilder(test);
+    protected override Func<JUnitTest, ITestResultXmlBuilder<JUnitTest>> BuilderFactory   => test    => new JUnitTestResultXmlBuilder(test, _jUnitOptions);
     protected override string Extension                                                   => "xml";
 }

--- a/source/trx2junit.Core/Internal/trx2junit/Trx2JunitTestResultXmlConverter.cs
+++ b/source/trx2junit.Core/Internal/trx2junit/Trx2JunitTestResultXmlConverter.cs
@@ -15,7 +15,7 @@ internal sealed class Trx2JunitTestResultXmlConverter : TestResultXmlConverter<T
     public Trx2JunitTestResultXmlConverter(JUnitOptions jUnitOptions) => _jUnitOptions = jUnitOptions;
     //-------------------------------------------------------------------------
     protected override Func<XElement, ITestResultXmlParser<TrxTest>> ParserFactory        => testXml => new TrxTestResultXmlParser(testXml);
-    protected override Func<TrxTest, ITestConverter<TrxTest, JUnitTest>> ConverterFactory => test    => new Trx2JunitTestConverter(test);
-    protected override Func<JUnitTest, ITestResultXmlBuilder<JUnitTest>> BuilderFactory   => test    => new JUnitTestResultXmlBuilder(test, _jUnitOptions);
+    protected override Func<TrxTest, ITestConverter<TrxTest, JUnitTest>> ConverterFactory => test    => new Trx2JunitTestConverter(test, _jUnitOptions);
+    protected override Func<JUnitTest, ITestResultXmlBuilder<JUnitTest>> BuilderFactory   => test    => new JUnitTestResultXmlBuilder(test);
     protected override string Extension                                                   => "xml";
 }

--- a/source/trx2junit.Core/Worker.cs
+++ b/source/trx2junit.Core/Worker.cs
@@ -22,7 +22,14 @@ public class Worker
     private readonly IFileSystem  _fileSystem;
     private readonly IGlobHandler _globHandler;
 
+    /// <summary>
+    /// The event that gets fired when the <see cref="Worker"/> emits a notification.
+    /// </summary>
     public event EventHandler<WorkerNotificationEventArgs>? WorkerNotification;
+
+    /// <summary>
+    /// The event that gets fired when the <see cref="Worker"/> emits a error.
+    /// </summary>
     public event EventHandler<WorkerNotificationEventArgs>? WorkerErrorNotification;
     //-------------------------------------------------------------------------
     /// <summary>

--- a/source/trx2junit.Core/Worker.cs
+++ b/source/trx2junit.Core/Worker.cs
@@ -67,7 +67,7 @@ public class Worker
 
         if (options.ConvertToJunit)
         {
-            converter = new Trx2JunitTestResultXmlConverter();
+            converter = new Trx2JunitTestResultXmlConverter(JUnitOptions.Create(options));
             this.OnNotification($"Converting {options.InputFiles.Count} trx file(s) to JUnit-xml...");
         }
         else

--- a/source/trx2junit.Core/WorkerOptions.cs
+++ b/source/trx2junit.Core/WorkerOptions.cs
@@ -25,6 +25,12 @@ public class WorkerOptions
     /// trx to junit. When <c>false</c> the conversion is junit to trx.
     /// </summary>
     public bool ConvertToJunit { get; }
+
+    /// <summary>
+    /// If set to <c>true</c>, then the JUnit message attributes will be emitted
+    /// to system-out too.
+    /// </summary>
+    public bool JUnitMessagesToSystemOut { get; }
     //-------------------------------------------------------------------------
     /// <summary>
     /// Creates a new instance of <see cref="WorkerOptions"/>.
@@ -35,7 +41,11 @@ public class WorkerOptions
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="inputFiles"/> is <c>null</c>.
     /// </exception>
-    public WorkerOptions(IList<string> inputFiles, string? outputDirectory = null, bool convertToJunit = true)
+    public WorkerOptions(
+        IList<string> inputFiles,
+        string?       outputDirectory          = null,
+        bool          convertToJunit           = true,
+        bool          junitMessagesToSystemOut = false)
     {
 #if NET6_0_OR_GREATER
         ArgumentNullException.ThrowIfNull(inputFiles);
@@ -43,8 +53,9 @@ public class WorkerOptions
 #else
         this.InputFiles      = inputFiles ?? throw new ArgumentNullException(nameof(inputFiles));
 #endif
-        this.OutputDirectory = outputDirectory;
-        this.ConvertToJunit  = convertToJunit;
+        this.OutputDirectory          = outputDirectory;
+        this.ConvertToJunit           = convertToJunit;
+        this.JUnitMessagesToSystemOut = junitMessagesToSystemOut;
     }
     //-------------------------------------------------------------------------
     /// <summary>
@@ -65,10 +76,10 @@ public class WorkerOptions
 #else
         if (args is null) throw new ArgumentNullException(nameof(args));
 #endif
-
-        var inputFiles          = new List<string>();
-        string? outputDirectory = null;
-        bool convertToJunit     = true;
+        List<string> inputFiles       = new();
+        string? outputDirectory       = null;
+        bool convertToJunit           = true;
+        bool junitMessagesToSystemOut = false;
 
         for (int i = 0; i < args.Length; ++i)
         {
@@ -88,12 +99,16 @@ public class WorkerOptions
             {
                 convertToJunit = false;
             }
+            else if (args[i] == "--junit-messages-to-system-out")
+            {
+                junitMessagesToSystemOut = true;
+            }
             else
             {
                 inputFiles.Add(args[i]);
             }
         }
 
-        return new WorkerOptions(inputFiles, outputDirectory, convertToJunit);
+        return new WorkerOptions(inputFiles, outputDirectory, convertToJunit, junitMessagesToSystemOut);
     }
 }

--- a/source/trx2junit.Core/WorkerOptions.cs
+++ b/source/trx2junit.Core/WorkerOptions.cs
@@ -30,7 +30,7 @@ public class WorkerOptions
     /// If set to <c>true</c>, then the JUnit message attributes will be emitted
     /// to system-out too.
     /// </summary>
-    public bool JUnitMessagesToSystemOut { get; }
+    public bool JUnitMessagesToSystemErr { get; }
     //-------------------------------------------------------------------------
     /// <summary>
     /// Creates a new instance of <see cref="WorkerOptions"/>.
@@ -45,7 +45,7 @@ public class WorkerOptions
         IList<string> inputFiles,
         string?       outputDirectory          = null,
         bool          convertToJunit           = true,
-        bool          junitMessagesToSystemOut = false)
+        bool          junitMessagesToSystemErr = false)
     {
 #if NET6_0_OR_GREATER
         ArgumentNullException.ThrowIfNull(inputFiles);
@@ -55,7 +55,7 @@ public class WorkerOptions
 #endif
         this.OutputDirectory          = outputDirectory;
         this.ConvertToJunit           = convertToJunit;
-        this.JUnitMessagesToSystemOut = junitMessagesToSystemOut;
+        this.JUnitMessagesToSystemErr = junitMessagesToSystemErr;
     }
     //-------------------------------------------------------------------------
     /// <summary>
@@ -79,7 +79,7 @@ public class WorkerOptions
         List<string> inputFiles       = new();
         string? outputDirectory       = null;
         bool convertToJunit           = true;
-        bool junitMessagesToSystemOut = false;
+        bool junitMessagesToSystemErr = false;
 
         for (int i = 0; i < args.Length; ++i)
         {
@@ -99,9 +99,9 @@ public class WorkerOptions
             {
                 convertToJunit = false;
             }
-            else if (args[i] == "--junit-messages-to-system-out")
+            else if (args[i] == "--junit-messages-to-system-err")
             {
-                junitMessagesToSystemOut = true;
+                junitMessagesToSystemErr = true;
             }
             else
             {
@@ -109,6 +109,6 @@ public class WorkerOptions
             }
         }
 
-        return new WorkerOptions(inputFiles, outputDirectory, convertToJunit, junitMessagesToSystemOut);
+        return new WorkerOptions(inputFiles, outputDirectory, convertToJunit, junitMessagesToSystemErr);
     }
 }

--- a/source/trx2junit.Core/WorkerOptions.cs
+++ b/source/trx2junit.Core/WorkerOptions.cs
@@ -38,6 +38,7 @@ public class WorkerOptions
     /// <param name="inputFiles">See <see cref="InputFiles"/>.</param>
     /// <param name="outputDirectory">See <see cref="OutputDirectory"/>.</param>
     /// <param name="convertToJunit">See <see cref="ConvertToJunit"/>.</param>
+    /// <param name="junitMessagesToSystemErr">See <see cref="JUnitMessagesToSystemErr"/>.</param>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="inputFiles"/> is <c>null</c>.
     /// </exception>

--- a/source/trx2junit.Core/WorkerOptions.cs
+++ b/source/trx2junit.Core/WorkerOptions.cs
@@ -30,7 +30,7 @@ public class WorkerOptions
     /// If set to <c>true</c>, then the JUnit message attributes will be emitted
     /// to system-out too.
     /// </summary>
-    public bool JUnitMessagesToSystemErr { get; }
+    public bool JUnitMessagesToSystemErr { get; internal set; }
     //-------------------------------------------------------------------------
     /// <summary>
     /// Creates a new instance of <see cref="WorkerOptions"/>.
@@ -38,25 +38,19 @@ public class WorkerOptions
     /// <param name="inputFiles">See <see cref="InputFiles"/>.</param>
     /// <param name="outputDirectory">See <see cref="OutputDirectory"/>.</param>
     /// <param name="convertToJunit">See <see cref="ConvertToJunit"/>.</param>
-    /// <param name="junitMessagesToSystemErr">See <see cref="JUnitMessagesToSystemErr"/>.</param>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="inputFiles"/> is <c>null</c>.
     /// </exception>
-    public WorkerOptions(
-        IList<string> inputFiles,
-        string?       outputDirectory          = null,
-        bool          convertToJunit           = true,
-        bool          junitMessagesToSystemErr = false)
+    public WorkerOptions(IList<string> inputFiles, string? outputDirectory = null, bool convertToJunit = true)
     {
 #if NET6_0_OR_GREATER
         ArgumentNullException.ThrowIfNull(inputFiles);
         this.InputFiles = inputFiles;
 #else
-        this.InputFiles      = inputFiles ?? throw new ArgumentNullException(nameof(inputFiles));
+        this.InputFiles = inputFiles ?? throw new ArgumentNullException(nameof(inputFiles));
 #endif
-        this.OutputDirectory          = outputDirectory;
-        this.ConvertToJunit           = convertToJunit;
-        this.JUnitMessagesToSystemErr = junitMessagesToSystemErr;
+        this.OutputDirectory = outputDirectory;
+        this.ConvertToJunit  = convertToJunit;
     }
     //-------------------------------------------------------------------------
     /// <summary>
@@ -110,6 +104,9 @@ public class WorkerOptions
             }
         }
 
-        return new WorkerOptions(inputFiles, outputDirectory, convertToJunit, junitMessagesToSystemErr);
+        return new WorkerOptions(inputFiles, outputDirectory, convertToJunit)
+        {
+            JUnitMessagesToSystemErr = junitMessagesToSystemErr
+        };
     }
 }

--- a/tests/trx2junit.Core.Tests/Internal/JUnitOptionsTests.cs
+++ b/tests/trx2junit.Core.Tests/Internal/JUnitOptionsTests.cs
@@ -13,7 +13,10 @@ public class JUnitOptionsTests
     [TestCase(false)]
     public void Create___parsed_from_WorkerOptions(bool jUnitMessagesToSystemOut)
     {
-        WorkerOptions workerOptions = new(new[] { "a.trx" }, junitMessagesToSystemErr: jUnitMessagesToSystemOut);
+        WorkerOptions workerOptions = new(new[] { "a.trx" })
+        {
+            JUnitMessagesToSystemErr = jUnitMessagesToSystemOut
+        };
 
         JUnitOptions sut = JUnitOptions.Create(workerOptions);
 

--- a/tests/trx2junit.Core.Tests/Internal/JUnitOptionsTests.cs
+++ b/tests/trx2junit.Core.Tests/Internal/JUnitOptionsTests.cs
@@ -13,10 +13,10 @@ public class JUnitOptionsTests
     [TestCase(false)]
     public void Create___parsed_from_WorkerOptions(bool jUnitMessagesToSystemOut)
     {
-        WorkerOptions workerOptions = new(new[] { "a.trx" }, junitMessagesToSystemOut: jUnitMessagesToSystemOut);
+        WorkerOptions workerOptions = new(new[] { "a.trx" }, junitMessagesToSystemErr: jUnitMessagesToSystemOut);
 
         JUnitOptions sut = JUnitOptions.Create(workerOptions);
 
-        Assert.AreEqual(jUnitMessagesToSystemOut, sut.JUnitMessagesToSystemOut);
+        Assert.AreEqual(jUnitMessagesToSystemOut, sut.JUnitMessagesToSystemErr);
     }
 }

--- a/tests/trx2junit.Core.Tests/Internal/JUnitOptionsTests.cs
+++ b/tests/trx2junit.Core.Tests/Internal/JUnitOptionsTests.cs
@@ -1,0 +1,22 @@
+// (c) gfoidl, all rights reserved
+
+using gfoidl.Trx2Junit.Core.Internal;
+using NUnit.Framework;
+
+namespace gfoidl.Trx2Junit.Core.Tests.Internal;
+
+[TestFixture]
+public class JUnitOptionsTests
+{
+    [Test]
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Create___parsed_from_WorkerOptions(bool jUnitMessagesToSystemOut)
+    {
+        WorkerOptions workerOptions = new(new[] { "a.trx" }, junitMessagesToSystemOut: jUnitMessagesToSystemOut);
+
+        JUnitOptions sut = JUnitOptions.Create(workerOptions);
+
+        Assert.AreEqual(jUnitMessagesToSystemOut, sut.JUnitMessagesToSystemOut);
+    }
+}

--- a/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Build/Base.cs
+++ b/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Build/Base.cs
@@ -18,7 +18,7 @@ public abstract class Base
     //-------------------------------------------------------------------------
     protected List<XElement> GetTestSuites()
     {
-        var builder = new JUnitTestResultXmlBuilder(_junitTest);
+        var builder = new JUnitTestResultXmlBuilder(_junitTest, new JUnitOptions());
 
         builder.Build();
 

--- a/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Build/Base.cs
+++ b/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Build/Base.cs
@@ -18,7 +18,7 @@ public abstract class Base
     //-------------------------------------------------------------------------
     protected List<XElement> GetTestSuites()
     {
-        var builder = new JUnitTestResultXmlBuilder(_junitTest, new JUnitOptions());
+        var builder = new JUnitTestResultXmlBuilder(_junitTest);
 
         builder.Build();
 

--- a/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Build/DataDriven.cs
+++ b/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Build/DataDriven.cs
@@ -47,7 +47,7 @@ public class DataDriven : Base
                 });
         }
 
-        var converter = new Trx2JunitTestConverter(_trxTest);
+        var converter = new Trx2JunitTestConverter(_trxTest, new JUnitOptions());
         converter.Convert();
         _junitTest     = converter.Result;
     }
@@ -55,7 +55,7 @@ public class DataDriven : Base
     [Test]
     public void Builds___OK()
     {
-        var sut = new JUnitTestResultXmlBuilder(_junitTest, new JUnitOptions());
+        var sut = new JUnitTestResultXmlBuilder(_junitTest);
 
         sut.Build();
     }

--- a/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Build/DataDriven.cs
+++ b/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Build/DataDriven.cs
@@ -55,7 +55,7 @@ public class DataDriven : Base
     [Test]
     public void Builds___OK()
     {
-        var sut = new JUnitTestResultXmlBuilder(_junitTest);
+        var sut = new JUnitTestResultXmlBuilder(_junitTest, new JUnitOptions());
 
         sut.Build();
     }

--- a/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Build/Default.cs
+++ b/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Build/Default.cs
@@ -60,7 +60,7 @@ public class Default : Base
     [Test]
     public void Builds___OK()
     {
-        var sut = new JUnitTestResultXmlBuilder(_junitTest);
+        var sut = new JUnitTestResultXmlBuilder(_junitTest, new JUnitOptions());
 
         sut.Build();
     }

--- a/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Build/Default.cs
+++ b/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Build/Default.cs
@@ -23,7 +23,7 @@ public class Default : Base
         AddTestResult("Class4", "Method1", TrxOutcome.Completed  , new TimeSpan(0, 0,  1));
         AddTestResult("Class4", "Method2", TrxOutcome.Warning    , new TimeSpan(0, 0,  1));
 
-        var converter = new Trx2JunitTestConverter(_trxTest);
+        var converter = new Trx2JunitTestConverter(_trxTest, new JUnitOptions());
         converter.Convert();
         _junitTest = converter.Result;
         //---------------------------------------------------------------------
@@ -60,7 +60,7 @@ public class Default : Base
     [Test]
     public void Builds___OK()
     {
-        var sut = new JUnitTestResultXmlBuilder(_junitTest, new JUnitOptions());
+        var sut = new JUnitTestResultXmlBuilder(_junitTest);
 
         sut.Build();
     }

--- a/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Integration.cs
+++ b/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Integration.cs
@@ -12,6 +12,8 @@ namespace gfoidl.Trx2Junit.Core.Tests.Internal.JUnitTestResultXmlBuilderTests;
 [TestFixture]
 public class Integration
 {
+    private static readonly JUnitOptions s_jUnitOptions = new();
+    //-------------------------------------------------------------------------
     [Test]
     [TestCase("./data/trx/mstest.trx"           , 3, 1)]
     [TestCase("./data/trx/mstest-datadriven.trx", 5, 2)]
@@ -38,7 +40,7 @@ public class Integration
         converter.Convert();
 
         JUnitTest junitTest = converter.Result;
-        var sut             = new JUnitTestResultXmlBuilder(junitTest);
+        var sut             = new JUnitTestResultXmlBuilder(junitTest, s_jUnitOptions);
         sut.Build();
 
         XElement testsuite = sut.Result.Elements("testsuite").First();
@@ -63,7 +65,7 @@ public class Integration
         converter.Convert();
 
         JUnitTest junitTest = converter.Result;
-        var sut             = new JUnitTestResultXmlBuilder(junitTest);
+        var sut             = new JUnitTestResultXmlBuilder(junitTest, s_jUnitOptions);
         sut.Build();
 
         XElement testsuite = sut.Result.Elements("testsuite").First();
@@ -86,7 +88,7 @@ public class Integration
         converter.Convert();
 
         JUnitTest junitTest = converter.Result;
-        var sut             = new JUnitTestResultXmlBuilder(junitTest);
+        var sut             = new JUnitTestResultXmlBuilder(junitTest, s_jUnitOptions);
         sut.Build();
 
         XElement testsuite = sut.Result.Elements("testsuite").First();
@@ -110,7 +112,7 @@ public class Integration
         converter.Convert();
 
         JUnitTest junitTest = converter.Result;
-        var sut             = new JUnitTestResultXmlBuilder(junitTest);
+        var sut             = new JUnitTestResultXmlBuilder(junitTest, s_jUnitOptions);
         sut.Build();
 
         XElement testsuite = sut.Result.Elements("testsuite").First();
@@ -133,7 +135,7 @@ public class Integration
         converter.Convert();
 
         JUnitTest junitTest = converter.Result;
-        var sut             = new JUnitTestResultXmlBuilder(junitTest);
+        var sut             = new JUnitTestResultXmlBuilder(junitTest, s_jUnitOptions);
         sut.Build();
 
         XElement testsuite = sut.Result.Elements("testsuite").First();
@@ -157,7 +159,7 @@ public class Integration
         converter.Convert();
 
         JUnitTest junitTest = converter.Result;
-        var sut             = new JUnitTestResultXmlBuilder(junitTest);
+        var sut             = new JUnitTestResultXmlBuilder(junitTest, s_jUnitOptions);
         sut.Build();
 
         XElement[] testCases = sut.Result.Descendants("testcase").ToArray();
@@ -169,5 +171,32 @@ public class Integration
             Assert.AreEqual("0", testCases[1].Attribute("status").Value);
             Assert.AreEqual("1", testCases[2].Attribute("status").Value);
         });
+    }
+    //-------------------------------------------------------------------------
+    [Test]
+    public void JUnit_message_to_system_out_set___messages_written_to_system_out([Values(true, false)] bool value)
+    {
+        XElement trx = XElement.Load("./data/trx/nunit-ignore.trx");
+        var parser   = new TrxTestResultXmlParser(trx);
+
+        parser.Parse();
+        TrxTest testData = parser.Result;
+
+        var converter = new Trx2JunitTestConverter(testData);
+        converter.Convert();
+
+        JUnitTest junitTest = converter.Result;
+        var sut             = new JUnitTestResultXmlBuilder(junitTest, new JUnitOptions { JUnitMessagesToSystemOut = value });
+        sut.Build();
+
+        XElement systemOut = sut.Result.Descendants("system-out").SingleOrDefault();
+        if (value)
+        {
+            StringAssert.Contains("Failing for demo purposes", systemOut.Value);
+        }
+        else
+        {
+            StringAssert.DoesNotContain("Failing for demo purposes", systemOut.Value);
+        }
     }
 }

--- a/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Integration.cs
+++ b/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Integration.cs
@@ -36,11 +36,11 @@ public class Integration
         parser.Parse();
         TrxTest testData = parser.Result;
 
-        var converter = new Trx2JunitTestConverter(testData);
+        var converter = new Trx2JunitTestConverter(testData, s_jUnitOptions);
         converter.Convert();
 
         JUnitTest junitTest = converter.Result;
-        var sut             = new JUnitTestResultXmlBuilder(junitTest, s_jUnitOptions);
+        var sut             = new JUnitTestResultXmlBuilder(junitTest);
         sut.Build();
 
         XElement testsuite = sut.Result.Elements("testsuite").First();
@@ -61,11 +61,11 @@ public class Integration
         parser.Parse();
         TrxTest testData = parser.Result;
 
-        var converter = new Trx2JunitTestConverter(testData);
+        var converter = new Trx2JunitTestConverter(testData, s_jUnitOptions);
         converter.Convert();
 
         JUnitTest junitTest = converter.Result;
-        var sut             = new JUnitTestResultXmlBuilder(junitTest, s_jUnitOptions);
+        var sut             = new JUnitTestResultXmlBuilder(junitTest);
         sut.Build();
 
         XElement testsuite = sut.Result.Elements("testsuite").First();
@@ -84,11 +84,11 @@ public class Integration
         parser.Parse();
         TrxTest testData = parser.Result;
 
-        var converter = new Trx2JunitTestConverter(testData);
+        var converter = new Trx2JunitTestConverter(testData, s_jUnitOptions);
         converter.Convert();
 
         JUnitTest junitTest = converter.Result;
-        var sut             = new JUnitTestResultXmlBuilder(junitTest, s_jUnitOptions);
+        var sut             = new JUnitTestResultXmlBuilder(junitTest);
         sut.Build();
 
         XElement testsuite = sut.Result.Elements("testsuite").First();
@@ -108,11 +108,11 @@ public class Integration
         parser.Parse();
         TrxTest testData = parser.Result;
 
-        var converter = new Trx2JunitTestConverter(testData);
+        var converter = new Trx2JunitTestConverter(testData, s_jUnitOptions);
         converter.Convert();
 
         JUnitTest junitTest = converter.Result;
-        var sut             = new JUnitTestResultXmlBuilder(junitTest, s_jUnitOptions);
+        var sut             = new JUnitTestResultXmlBuilder(junitTest);
         sut.Build();
 
         XElement testsuite = sut.Result.Elements("testsuite").First();
@@ -131,11 +131,11 @@ public class Integration
         parser.Parse();
         TrxTest testData = parser.Result;
 
-        var converter = new Trx2JunitTestConverter(testData);
+        var converter = new Trx2JunitTestConverter(testData, s_jUnitOptions);
         converter.Convert();
 
         JUnitTest junitTest = converter.Result;
-        var sut             = new JUnitTestResultXmlBuilder(junitTest, s_jUnitOptions);
+        var sut             = new JUnitTestResultXmlBuilder(junitTest);
         sut.Build();
 
         XElement testsuite = sut.Result.Elements("testsuite").First();
@@ -155,11 +155,11 @@ public class Integration
         parser.Parse();
         TrxTest testData = parser.Result;
 
-        var converter = new Trx2JunitTestConverter(testData);
+        var converter = new Trx2JunitTestConverter(testData, s_jUnitOptions);
         converter.Convert();
 
         JUnitTest junitTest = converter.Result;
-        var sut             = new JUnitTestResultXmlBuilder(junitTest, s_jUnitOptions);
+        var sut             = new JUnitTestResultXmlBuilder(junitTest);
         sut.Build();
 
         XElement[] testCases = sut.Result.Descendants("testcase").ToArray();
@@ -174,7 +174,7 @@ public class Integration
     }
     //-------------------------------------------------------------------------
     [Test]
-    public void JUnit_message_to_system_out_set___messages_written_to_system_out([Values(true, false)] bool value)
+    public void JUnit_message_to_system_err_set___messages_written_to_system_out([Values(true, false)] bool value)
     {
         XElement trx = XElement.Load("./data/trx/nunit-ignore.trx");
         var parser   = new TrxTestResultXmlParser(trx);
@@ -182,21 +182,29 @@ public class Integration
         parser.Parse();
         TrxTest testData = parser.Result;
 
-        var converter = new Trx2JunitTestConverter(testData);
+        var converter = new Trx2JunitTestConverter(testData, new JUnitOptions { JUnitMessagesToSystemErr = value });
         converter.Convert();
 
         JUnitTest junitTest = converter.Result;
-        var sut             = new JUnitTestResultXmlBuilder(junitTest, new JUnitOptions { JUnitMessagesToSystemOut = value });
+        var sut             = new JUnitTestResultXmlBuilder(junitTest);
         sut.Build();
 
-        XElement systemOut = sut.Result.Descendants("system-out").SingleOrDefault();
+        XElement testsuite = sut.Result.Elements("testsuite").First();
+        XElement testcase  = testsuite.Elements("testcase").Skip(1).First();
+        XElement systemErr = testcase.Element("system-err");
+
+
         if (value)
         {
-            StringAssert.Contains("Failing for demo purposes", systemOut.Value);
+            Assert.Multiple(() =>
+            {
+                Assert.IsNotNull(systemErr, nameof(systemErr));
+                StringAssert.Contains("Failing for demo purposes", systemErr.Value);
+            });
         }
         else
         {
-            StringAssert.DoesNotContain("Failing for demo purposes", systemOut.Value);
+            Assert.IsNull(systemErr, nameof(systemErr));
         }
     }
 }

--- a/tests/trx2junit.Core.Tests/WorkerOptionsTests/Parse.cs
+++ b/tests/trx2junit.Core.Tests/WorkerOptionsTests/Parse.cs
@@ -21,6 +21,7 @@ public class Parse
             CollectionAssert.AreEqual(expected, actual.InputFiles);
             Assert.IsNull(actual.OutputDirectory);
             Assert.IsTrue(actual.ConvertToJunit);
+            Assert.IsFalse(actual.JUnitMessagesToSystemOut);
         });
     }
     //-------------------------------------------------------------------------
@@ -149,6 +150,20 @@ public class Parse
         Assert.Multiple(() =>
         {
             Assert.IsFalse(actual.ConvertToJunit);
+            CollectionAssert.AreEqual(new string[] { "a.trx" }, actual.InputFiles);
+        });
+    }
+    //-------------------------------------------------------------------------
+    [Test]
+    public void JUnitMessagesToSystemOut___option_true()
+    {
+        string[] args = { "a.trx", "--junit-messages-to-system-out" };
+
+        var actual = WorkerOptions.Parse(args);
+
+        Assert.Multiple(() =>
+        {
+            Assert.IsTrue(actual.JUnitMessagesToSystemOut);
             CollectionAssert.AreEqual(new string[] { "a.trx" }, actual.InputFiles);
         });
     }

--- a/tests/trx2junit.Core.Tests/WorkerOptionsTests/Parse.cs
+++ b/tests/trx2junit.Core.Tests/WorkerOptionsTests/Parse.cs
@@ -21,7 +21,7 @@ public class Parse
             CollectionAssert.AreEqual(expected, actual.InputFiles);
             Assert.IsNull(actual.OutputDirectory);
             Assert.IsTrue(actual.ConvertToJunit);
-            Assert.IsFalse(actual.JUnitMessagesToSystemOut);
+            Assert.IsFalse(actual.JUnitMessagesToSystemErr);
         });
     }
     //-------------------------------------------------------------------------
@@ -157,13 +157,13 @@ public class Parse
     [Test]
     public void JUnitMessagesToSystemOut___option_true()
     {
-        string[] args = { "a.trx", "--junit-messages-to-system-out" };
+        string[] args = { "a.trx", "--junit-messages-to-system-err" };
 
         var actual = WorkerOptions.Parse(args);
 
         Assert.Multiple(() =>
         {
-            Assert.IsTrue(actual.JUnitMessagesToSystemOut);
+            Assert.IsTrue(actual.JUnitMessagesToSystemErr);
             CollectionAssert.AreEqual(new string[] { "a.trx" }, actual.InputFiles);
         });
     }

--- a/tests/trx2junit.Core.Tests/WorkerTests/ConvertAsync.cs
+++ b/tests/trx2junit.Core.Tests/WorkerTests/ConvertAsync.cs
@@ -55,7 +55,7 @@ public class ConvertAsync
         string junitFile = Path.ChangeExtension(trxFile, "xml");
         var sut          = new Worker();
 
-        await sut.ConvertAsync(new Trx2JunitTestResultXmlConverter(), trxFile);
+        await sut.ConvertAsync(new Trx2JunitTestResultXmlConverter(new JUnitOptions()), trxFile);
 
         bool actual = File.Exists(junitFile);
         Assert.IsTrue(actual);
@@ -81,7 +81,7 @@ public class ConvertAsync
         string junitFile = Path.ChangeExtension(trxFile, "xml");
         var sut          = new Worker();
 
-        await sut.ConvertAsync(new Trx2JunitTestResultXmlConverter(), trxFile);
+        await sut.ConvertAsync(new Trx2JunitTestResultXmlConverter(new JUnitOptions()), trxFile);
 
         ValidationHelper.IsXmlValidJunit(junitFile, validateJunit: true);
     }


### PR DESCRIPTION
Fixes https://github.com/gfoidl/trx2junit/issues/97

When CLI-flag `--junit-messages-to-system-err` is set or when `WorkerOptions.JUnitMessagesToSystemErr` is set, then failure messages are emitted to _system-err_ on that testcase too.

E.g. when the flag is not set, then the junit-file will look like:
```xml
<?xml version="1.0" encoding="utf-8"?>
<testsuites>
    <testsuite name="NUnitSample.SimpleTests" hostname="xyz" package="not available" id="0" tests="1" failures="1" errors="0" skipped="0" time="1.074" timestamp="2019-04-19T16:06:41">
        <properties />
        <testcase name="Failing_test" classname="NUnitSample.SimpleTests" time="0.059" status="0">
            <failure message="Failing for demo purposes" type="not specified">
                at NUnitSample.SimpleTests.Failing_test() in ...trx2junit\samples\NUnitSample\SimpleTests.cs:line 21
            </failure>
        </testcase>
        <system-out />
        <system-err />
    </testsuite>
</testsuites>
``` 

With `--junit-messages-to-system-err` set the junit-file looks like:
```xml
<?xml version="1.0" encoding="utf-8"?>
<testsuites>
    <testsuite name="NUnitSample.SimpleTests" hostname="xyz" package="not available" id="0" tests="1" failures="1" errors="0" skipped="0" time="1.074" timestamp="2019-04-19T16:06:41">
        <properties />
        <testcase name="Failing_test" classname="NUnitSample.SimpleTests" time="0.059" status="0">
            <failure message="Failing for demo purposes" type="not specified">
                at NUnitSample.SimpleTests.Failing_test() in ...trx2junit\samples\NUnitSample\SimpleTests.cs:line 21
            </failure>
            <system-err>
                Failing for demo purposes
            </system-err>
        </testcase>
        <system-out />
        <system-err>Failing for demo purposes</system-err>
    </testsuite>
</testsuites>
```
