### PR TITLE
JUnit: emit failure content with message as CData element

### DIFF
--- a/source/trx2junit.Core/Internal/trx2junit/JUnitTestResultXmlBuilder.cs
+++ b/source/trx2junit.Core/Internal/trx2junit/JUnitTestResultXmlBuilder.cs
@@ -94,8 +94,10 @@ internal sealed class JUnitTestResultXmlBuilder : ITestResultXmlBuilder<JUnitTes
         }
         else if (testCase.Error != null)
         {
+            string failureContent = $"{testCase.Error.Message}\n{testCase.Error.StackTrace}";
+
             xTestCase.Add(new XElement("failure",
-                testCase.Error.StackTrace!,
+                failureContent.TrimEnd(),
                 new XAttribute("message", testCase.Error.Message!),
                 new XAttribute("type"   , testCase.Error.Type!)
             ));

--- a/source/trx2junit.Core/Internal/trx2junit/JUnitTestResultXmlBuilder.cs
+++ b/source/trx2junit.Core/Internal/trx2junit/JUnitTestResultXmlBuilder.cs
@@ -94,10 +94,10 @@ internal sealed class JUnitTestResultXmlBuilder : ITestResultXmlBuilder<JUnitTes
         }
         else if (testCase.Error != null)
         {
-            string failureContent = $"{testCase.Error.Message}\n{testCase.Error.StackTrace}";
+            string failureContent = $"{testCase.Error.Message}\n{testCase.Error.StackTrace?.TrimEnd()}";
 
             xTestCase.Add(new XElement("failure",
-                failureContent.TrimEnd(),
+                new XCData(failureContent),
                 new XAttribute("message", testCase.Error.Message!),
                 new XAttribute("type"   , testCase.Error.Type!)
             ));

--- a/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Integration.cs
+++ b/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Integration.cs
@@ -74,11 +74,18 @@ public class Integration
         {
             Assert.AreEqual("Failing for demo purposes", failure.Attribute("message").Value);
 
-            string expectedContent = @"Failing for demo purposes
-   at NUnitSample.SimpleTests.Failing_test() in D:\Work-Git\github\Mini\trx2junit\samples\NUnitSample\SimpleTests.cs:line 21";
+            string expectedContent = @"<![CDATA[Failing for demo purposes
+   at NUnitSample.SimpleTests.Failing_test() in D:\Work-Git\github\Mini\trx2junit\samples\NUnitSample\SimpleTests.cs:line 21]]>";
+            string actualContent   = failure.LastNode.ToString();
 
-            Assert.AreEqual(expectedContent, failure.Value);
+            expectedContent = NormalizeLineEndings(expectedContent);
+            actualContent   = NormalizeLineEndings(actualContent);
+
+            Assert.AreEqual(expectedContent, actualContent);
         });
+
+        static string NormalizeLineEndings(string input)
+            => input.Replace("\r\n", "\n");
     }
     //-------------------------------------------------------------------------
     [Test]

--- a/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Integration.cs
+++ b/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Integration.cs
@@ -51,6 +51,37 @@ public class Integration
     }
     //-------------------------------------------------------------------------
     [Test]
+    public void TrxUnitTestResult_with_error___failure_element_populated()
+    {
+        XElement trx = XElement.Load("./data/trx/nunit-ignore.trx");
+        var parser   = new TrxTestResultXmlParser(trx);
+
+        parser.Parse();
+        TrxTest testData = parser.Result;
+
+        var converter = new Trx2JunitTestConverter(testData);
+        converter.Convert();
+
+        JUnitTest junitTest = converter.Result;
+        var sut             = new JUnitTestResultXmlBuilder(junitTest);
+        sut.Build();
+
+        XElement testsuite = sut.Result.Elements("testsuite").First();
+        XElement testcase  = testsuite.Elements("testcase").Skip(1).First();
+        XElement failure   = testcase.Element("failure");
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual("Failing for demo purposes", failure.Attribute("message").Value);
+
+            string expectedContent = @"Failing for demo purposes
+   at NUnitSample.SimpleTests.Failing_test() in D:\Work-Git\github\Mini\trx2junit\samples\NUnitSample\SimpleTests.cs:line 21";
+
+            Assert.AreEqual(expectedContent, failure.Value);
+        });
+    }
+    //-------------------------------------------------------------------------
+    [Test]
     public void TrxUnitTestResult_with_stdout___system_out_set()
     {
         XElement trx = XElement.Load("./data/trx/nunit-with-stdout.trx");


### PR DESCRIPTION
Fixes #97

https://github.com/gfoidl/trx2junit/pull/100 didn't solve the (underlying) issue, and that solution is a bit awkward anyway.

---

For trx -> junit instead of emitting
```xml
<?xml version="1.0" encoding="utf-8"?>
<testsuites>
    <testsuite name="NUnitSample.SimpleTests" hostname="xyz" package="not available" id="0" tests="1" failures="1" errors="0" skipped="0" time="1.074" timestamp="2019-04-19T16:06:41">
        <properties />
        <testcase name="Failing_test" classname="NUnitSample.SimpleTests" time="0.059" status="0">
            <failure message="Failing for demo purposes" type="not specified">
                at NUnitSample.SimpleTests.Failing_test() in ...trx2junit\samples\NUnitSample\SimpleTests.cs:line 21
            </failure>
        </testcase>
        <system-out />
        <system-err />
    </testsuite>
</testsuites>
```
it now emits
```xml
<?xml version="1.0" encoding="utf-8"?>
<testsuites>
    <testsuite name="NUnitSample.SimpleTests" hostname="GFOIDL-PC-2018" package="not available" id="0" tests="5" failures="1" errors="0" skipped="2" time="1.074" timestamp="2019-04-19T16:06:41">
        <properties />
        <testcase name="Passing_test" classname="NUnitSample.SimpleTests" time="0.001" status="1" />
        <testcase name="Failing_test" classname="NUnitSample.SimpleTests" time="0.059" status="0">
            <failure message="Failing for demo purposes" type="not specified">
                <![CDATA[Failing for demo purposes
   at NUnitSample.SimpleTests.Failing_test() in ...trx2junit\samples\NUnitSample\SimpleTests.cs:line 21]]>
            </failure>
        </testcase>
        <testcase name="Ignored_test" classname="NUnitSample.SimpleTests" time="0.001">
            <skipped />
        </testcase>
        <testcase name="Slow_test" classname="NUnitSample.SimpleTests" time="1.002" status="1" />
        <testcase name="Test_with_failed_assumption" classname="NUnitSample.SimpleTests" time="0.011">
            <skipped />
        </testcase>
        <system-out />
        <system-err />
    </testsuite>
</testsuites>
```