### PR TITLE
Fixed XUnit's testcase name to be not the full-qualified name

### DIFF
--- a/source/trx2junit.Core/Extensions/StringExtensions.cs
+++ b/source/trx2junit.Core/Extensions/StringExtensions.cs
@@ -1,0 +1,22 @@
+// (c) gfoidl, all rights reserved
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace gfoidl.Trx2Junit.Core;
+
+internal static class StringExtensions
+{
+    [return: NotNullIfNotNull("name")]
+    public static string? StripTypeInfo(this string? name)
+    {
+        if (name is null) return null;
+
+        int idx = name.LastIndexOf('.');
+        if (idx < 0)
+        {
+            return name;
+        }
+
+        return name[(idx + 1)..];
+    }
+}

--- a/source/trx2junit.Core/Internal/trx2junit/Trx2JunitTestConverter.cs
+++ b/source/trx2junit.Core/Internal/trx2junit/Trx2JunitTestConverter.cs
@@ -78,7 +78,7 @@ internal sealed class Trx2JunitTestConverter : ITestConverter<TrxTest, JUnitTest
             junitTestSuite.TestCases.Add(junitTestCase);
 
             junitTestSuite.HostName = trxUnitTestResult.ComputerName;
-            junitTestCase.Name      = trxTestDefinition.TestMethod;
+            junitTestCase.Name      = trxUnitTestResult.TestName;
             junitTestCase.ClassName = trxTestDefinition.TestClass;
 
             if (!_counters.TimeStamp.HasValue)

--- a/source/trx2junit.Core/Internal/trx2junit/Trx2JunitTestConverter.cs
+++ b/source/trx2junit.Core/Internal/trx2junit/Trx2JunitTestConverter.cs
@@ -78,7 +78,7 @@ internal sealed class Trx2JunitTestConverter : ITestConverter<TrxTest, JUnitTest
             junitTestSuite.TestCases.Add(junitTestCase);
 
             junitTestSuite.HostName = trxUnitTestResult.ComputerName;
-            junitTestCase.Name      = trxUnitTestResult.TestName;
+            junitTestCase.Name      = trxTestDefinition.TestMethod;
             junitTestCase.ClassName = trxTestDefinition.TestClass;
 
             if (!_counters.TimeStamp.HasValue)

--- a/source/trx2junit.Core/Internal/trx2junit/TrxTestResultXmlParser.cs
+++ b/source/trx2junit.Core/Internal/trx2junit/TrxTestResultXmlParser.cs
@@ -79,7 +79,7 @@ internal sealed class TrxTestResultXmlParser : TrxBase, ITestResultXmlParser<Trx
             testDefinition.Id          = xUnitTest.ReadGuid("id");
             testDefinition.ExecutionId = xUnitTest.Element(s_XN + "Execution")?.ReadGuid("id");
             testDefinition.TestClass   = xUnitTest.Element(s_XN + "TestMethod")?.Attribute("className")!.Value;
-            testDefinition.TestMethod  = xUnitTest.Element(s_XN + "TestMethod")?.Attribute("name")?.Value;
+            testDefinition.TestMethod  = xUnitTest.Element(s_XN + "TestMethod")?.Attribute("name")?.Value.StripTypeInfo();
 
             _test.TestDefinitions.Add(testDefinition);
         }
@@ -156,7 +156,7 @@ internal sealed class TrxTestResultXmlParser : TrxBase, ITestResultXmlParser<Trx
             Outcome      = ReadOutcome(xResult.Attribute("outcome")?.Value, isRequired: false),
             StartTime    = xResult.ReadDateTime("startTime"),
             TestId       = xResult.ReadGuid("testId"),
-            TestName     = xResult.Attribute("testName")?.Value,
+            TestName     = xResult.Attribute("testName")?.Value.StripTypeInfo(),
             ComputerName = xResult.Attribute("computerName")?.Value
         };
 

--- a/tests/trx2junit.Core.Tests/Extensions/StringExtensionsTests/StripTypeInfo.cs
+++ b/tests/trx2junit.Core.Tests/Extensions/StringExtensionsTests/StripTypeInfo.cs
@@ -1,0 +1,31 @@
+// (c) gfoidl, all rights reserved
+
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace gfoidl.Trx2Junit.Core.Tests.Extensions.StringExtensionsTests;
+
+[TestFixture]
+public class StripTypeInfo
+{
+    [Test, TestCaseSource(nameof(Name_given___correct_Name_returned_TestCases))]
+    public string Name_given___correct_Name_returned(string name)
+    {
+        return name.StripTypeInfo();
+    }
+    //-------------------------------------------------------------------------
+    private static IEnumerable<TestCaseData> Name_given___correct_Name_returned_TestCases()
+    {
+        yield return new TestCaseData(null).Returns(null);
+        yield return new TestCaseData("").Returns("");
+
+        yield return new TestCaseData("Method1")                .Returns("Method1");
+        yield return new TestCaseData("Method1(arg: { a = 3 })").Returns("Method1(arg: { a = 3 })");
+
+        yield return new TestCaseData("Class1.Method1")                .Returns("Method1");
+        yield return new TestCaseData("Class1.Method1(arg: { a = 3 })").Returns("Method1(arg: { a = 3 })");
+
+        yield return new TestCaseData("SimpleUnitTest.Class1.Method1")                .Returns("Method1");
+        yield return new TestCaseData("SimpleUnitTest.Class1.Method1(arg: { a = 3 })").Returns("Method1(arg: { a = 3 })");
+    }
+}

--- a/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Build/DataDriven.cs
+++ b/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Build/DataDriven.cs
@@ -35,7 +35,7 @@ public class DataDriven : Base
                 {
                     ExecutionId  = testExecGuid,
                     TestId       = testGuid,
-                    TestName     = $"SimpleUnitTest.Class1.Method1(arg: {i})",
+                    TestName     = $"Method1(arg: {i})",
                     Outcome      = i != 0 ? TrxOutcome.Passed : TrxOutcome.Failed,
                     Duration     = new TimeSpan(0, 0, 1),
                     StartTime    = DateTime.Now,

--- a/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Build/DataDriven.cs
+++ b/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Build/DataDriven.cs
@@ -1,6 +1,7 @@
 // (c) gfoidl, all rights reserved
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Xml.Linq;
@@ -15,29 +16,26 @@ public class DataDriven : Base
 {
     public DataDriven()
     {
-        var testGuid      = Guid.NewGuid();
-        var testExecGuids = Enumerable
-            .Range(0, 4)
-            .Select(_ => Guid.NewGuid())
-            .ToList();
-
-        _trxTest.TestDefinitions.Add(
-            new TrxTestDefinition
-            {
-                Id          = testGuid,
-                TestClass   = "Class1",
-                TestMethod  = "Method1",
-                ExecutionId = testExecGuids[0]
-            });
-
-        for (int i = 0; i < testExecGuids.Count; ++i)
+        for (int i = 0; i < 4; ++i)
         {
+            var testGuid     = Guid.NewGuid();
+            var testExecGuid = Guid.NewGuid();
+
+            _trxTest.TestDefinitions.Add(
+                new TrxTestDefinition
+                {
+                    Id          = testGuid,
+                    TestClass   = "SimpleUnitTest.Class1",
+                    TestMethod  = $"Method1(arg: {i})",
+                    ExecutionId = testExecGuid
+                });
+
             _trxTest.UnitTestResults.Add(
                 new TrxUnitTestResult
                 {
-                    ExecutionId  = testExecGuids[i],
+                    ExecutionId  = testExecGuid,
                     TestId       = testGuid,
-                    TestName     = "Method1",
+                    TestName     = $"SimpleUnitTest.Class1.Method1(arg: {i})",
                     Outcome      = i != 0 ? TrxOutcome.Passed : TrxOutcome.Failed,
                     Duration     = new TimeSpan(0, 0, 1),
                     StartTime    = DateTime.Now,
@@ -49,7 +47,7 @@ public class DataDriven : Base
 
         var converter = new Trx2JunitTestConverter(_trxTest);
         converter.Convert();
-        _junitTest     = converter.Result;
+        _junitTest    = converter.Result;
     }
     //-------------------------------------------------------------------------
     [Test]
@@ -65,7 +63,30 @@ public class DataDriven : Base
     {
         XElement testsuite = this.GetTestSuite();
 
-        Assert.AreEqual("Class1", testsuite.Attribute("name").Value);
+        Assert.AreEqual("SimpleUnitTest.Class1", testsuite.Attribute("name").Value);
+    }
+    //-------------------------------------------------------------------------
+    [Test]
+    public void Correct_Test_Suite_Name_and_ClassName()
+    {
+        XElement testsuite       = this.GetTestSuite();
+        List<XElement> testcases = testsuite.Elements("testcase").ToList();
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual("SimpleUnitTest.Class1", testcases[0].Attribute("classname").Value);
+            Assert.AreEqual("SimpleUnitTest.Class1", testcases[1].Attribute("classname").Value);
+            Assert.AreEqual("SimpleUnitTest.Class1", testcases[2].Attribute("classname").Value);
+            Assert.AreEqual("SimpleUnitTest.Class1", testcases[3].Attribute("classname").Value);
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual("Method1(arg: 0)", testcases[0].Attribute("name").Value);
+            Assert.AreEqual("Method1(arg: 1)", testcases[1].Attribute("name").Value);
+            Assert.AreEqual("Method1(arg: 2)", testcases[2].Attribute("name").Value);
+            Assert.AreEqual("Method1(arg: 3)", testcases[3].Attribute("name").Value);
+        });
     }
     //-------------------------------------------------------------------------
     [Test]

--- a/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Build/Default.cs
+++ b/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Build/Default.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Xml.Linq;
 using gfoidl.Trx2Junit.Core.Internal;
 using gfoidl.Trx2Junit.Core.Models.Trx;
@@ -14,14 +15,14 @@ public class Default : Base
 {
     public Default()
     {
-        AddTestResult("Class1", "Method1", TrxOutcome.NotExecuted, new TimeSpan(0, 0,  1));
-        AddTestResult("Class1", "Method2", TrxOutcome.Failed     , new TimeSpan(0, 0,  3));
-        AddTestResult("Class1", "Method3", TrxOutcome.Failed     , new TimeSpan(0, 0,  2));
-        AddTestResult("Class2", "Method1", TrxOutcome.Passed     , new TimeSpan(0, 0,  3));
-        AddTestResult("Class3", "Method1", TrxOutcome.Failed     , new TimeSpan(0, 0,  8));
-        AddTestResult("Class3", "Method2", TrxOutcome.Passed     , new TimeSpan(0, 0, 12));
-        AddTestResult("Class4", "Method1", TrxOutcome.Completed  , new TimeSpan(0, 0,  1));
-        AddTestResult("Class4", "Method2", TrxOutcome.Warning    , new TimeSpan(0, 0,  1));
+        AddTestResult("SimpleUnitTest.Class1", "Method1", TrxOutcome.NotExecuted, new TimeSpan(0, 0,  1));
+        AddTestResult("SimpleUnitTest.Class1", "Method2", TrxOutcome.Failed     , new TimeSpan(0, 0,  3));
+        AddTestResult("SimpleUnitTest.Class1", "Method3", TrxOutcome.Failed     , new TimeSpan(0, 0,  2));
+        AddTestResult("SimpleUnitTest.Class2", "Method1", TrxOutcome.Passed     , new TimeSpan(0, 0,  3));
+        AddTestResult("SimpleUnitTest.Class3", "Method1", TrxOutcome.Failed     , new TimeSpan(0, 0,  8));
+        AddTestResult("SimpleUnitTest.Class3", "Method2", TrxOutcome.Passed     , new TimeSpan(0, 0, 12));
+        AddTestResult("SimpleUnitTest.Class4", "Method1", TrxOutcome.Completed  , new TimeSpan(0, 0,  1));
+        AddTestResult("SimpleUnitTest.Class4", "Method2", TrxOutcome.Warning    , new TimeSpan(0, 0,  1));
 
         var converter = new Trx2JunitTestConverter(_trxTest);
         converter.Convert();
@@ -72,10 +73,60 @@ public class Default : Base
 
         Assert.Multiple(() =>
         {
-            Assert.AreEqual("Class1", testsuiteList[0].Attribute("name").Value);
-            Assert.AreEqual("Class2", testsuiteList[1].Attribute("name").Value);
-            Assert.AreEqual("Class3", testsuiteList[2].Attribute("name").Value);
-            Assert.AreEqual("Class4", testsuiteList[3].Attribute("name").Value);
+            Assert.AreEqual("SimpleUnitTest.Class1", testsuiteList[0].Attribute("name").Value);
+            Assert.AreEqual("SimpleUnitTest.Class2", testsuiteList[1].Attribute("name").Value);
+            Assert.AreEqual("SimpleUnitTest.Class3", testsuiteList[2].Attribute("name").Value);
+            Assert.AreEqual("SimpleUnitTest.Class4", testsuiteList[3].Attribute("name").Value);
+        });
+    }
+    //-------------------------------------------------------------------------
+    [Test]
+    public void Correct_Test_Suite_Name_and_ClassName()
+    {
+        List<XElement> testsuiteList = this.GetTestSuites();
+
+        Assert.Multiple(() =>
+        {
+            List<XElement> testcases = testsuiteList[0].Elements("testcase").ToList();
+
+            Assert.AreEqual("SimpleUnitTest.Class1", testcases[0].Attribute("classname").Value);
+            Assert.AreEqual("SimpleUnitTest.Class1", testcases[1].Attribute("classname").Value);
+            Assert.AreEqual("SimpleUnitTest.Class1", testcases[2].Attribute("classname").Value);
+
+            Assert.AreEqual("Method1", testcases[0].Attribute("name").Value);
+            Assert.AreEqual("Method2", testcases[1].Attribute("name").Value);
+            Assert.AreEqual("Method3", testcases[2].Attribute("name").Value);
+        });
+
+        Assert.Multiple(() =>
+        {
+            List<XElement> testcases = testsuiteList[1].Elements("testcase").ToList();
+
+            Assert.AreEqual("SimpleUnitTest.Class2", testcases[0].Attribute("classname").Value);
+
+            Assert.AreEqual("Method1", testcases[0].Attribute("name").Value);
+        });
+
+        Assert.Multiple(() =>
+        {
+            List<XElement> testcases = testsuiteList[2].Elements("testcase").ToList();
+
+            Assert.AreEqual("SimpleUnitTest.Class3", testcases[0].Attribute("classname").Value);
+            Assert.AreEqual("SimpleUnitTest.Class3", testcases[1].Attribute("classname").Value);
+
+            Assert.AreEqual("Method1", testcases[0].Attribute("name").Value);
+            Assert.AreEqual("Method2", testcases[1].Attribute("name").Value);
+        });
+
+        Assert.Multiple(() =>
+        {
+            List<XElement> testcases = testsuiteList[3].Elements("testcase").ToList();
+
+            Assert.AreEqual("SimpleUnitTest.Class4", testcases[0].Attribute("classname").Value);
+            Assert.AreEqual("SimpleUnitTest.Class4", testcases[1].Attribute("classname").Value);
+
+            Assert.AreEqual("Method1", testcases[0].Attribute("name").Value);
+            Assert.AreEqual("Method2", testcases[1].Attribute("name").Value);
         });
     }
     //-------------------------------------------------------------------------

--- a/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Integration.cs
+++ b/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Integration.cs
@@ -22,7 +22,7 @@ public class Integration
     [TestCase("./data/trx/nunit-with-stdout.trx", 1, 0)]
     [TestCase("./data/trx/nunit-memberdata.trx" , 5, 2)]
     [TestCase("./data/trx/xunit.trx"            , 3, 1)]
-    [TestCase("./data/trx/xunit-datadriven.trx" , 3, 1)]
+    [TestCase("./data/trx/xunit-datadriven.trx" , 5, 2)]
     [TestCase("./data/trx/xunit-ignore.trx"     , 4, 1)]
     [TestCase("./data/trx/xunit-memberdata.trx" , 5, 2)]
     [TestCase("./data/trx/nunit-testresultaggregation.trx", 3, 1)]

--- a/tests/trx2junit.Core.Tests/Internal/TrxTestResultXmlParserTests/Parse.cs
+++ b/tests/trx2junit.Core.Tests/Internal/TrxTestResultXmlParserTests/Parse.cs
@@ -1,5 +1,6 @@
 // (c) gfoidl, all rights reserved
 
+using System.Linq;
 using System.Xml.Linq;
 using gfoidl.Trx2Junit.Core.Internal;
 using gfoidl.Trx2Junit.Core.Models.Trx;
@@ -65,5 +66,20 @@ public class Parse
             Assert.AreEqual(expectedTotalCount , actual.ResultSummary.Total , nameof(expectedTotalCount));
             Assert.AreEqual(expectedFailedCount, actual.ResultSummary.Failed, nameof(expectedFailedCount));
         });
+    }
+    //-------------------------------------------------------------------------
+    [Test]
+    [TestCase("./data/trx/nunit-datadriven.trx", "Two_pass_one_fails(2)")]
+    [TestCase("./data/trx/nunit-memberdata.trx", "Two_pass_one_fails({ index = 0 })")]
+    [TestCase("./data/trx/xunit-datadriven.trx", "Two_pass_one_fails(arg: 0)")]
+    public void File_given___corrent_TestName(string trxFile, string expectedName)
+    {
+        XElement trx = XElement.Load(trxFile);
+        var sut      = new TrxTestResultXmlParser(trx);
+
+        sut.Parse();
+        TrxTest actual = sut.Result;
+
+        Assert.AreEqual(expectedName, actual.TestDefinitions.First().TestMethod);
     }
 }

--- a/tests/trx2junit.Core.Tests/Internal/TrxTestResultXmlParserTests/Parse.cs
+++ b/tests/trx2junit.Core.Tests/Internal/TrxTestResultXmlParserTests/Parse.cs
@@ -70,7 +70,7 @@ public class Parse
     //-------------------------------------------------------------------------
     [Test]
     [TestCase("./data/trx/nunit-datadriven.trx", "Two_pass_one_fails(2)")]
-    [TestCase("./data/trx/nunit-memberdata.trx", "Two_pass_one_fails({ index = 0 })")]
+    [TestCase("./data/trx/nunit-memberdata.trx", "Two_pass_one_fails({ index = 1 })")]
     [TestCase("./data/trx/xunit-datadriven.trx", "Two_pass_one_fails(arg: 0)")]
     public void File_given___corrent_TestName(string trxFile, string expectedName)
     {
@@ -80,6 +80,10 @@ public class Parse
         sut.Parse();
         TrxTest actual = sut.Result;
 
-        Assert.AreEqual(expectedName, actual.TestDefinitions.First().TestMethod);
+        string actualTestName = actual.UnitTestResults
+            .First(u => u.TestName.Contains("Two_pass_one_fails"))
+            .TestName;
+
+        Assert.AreEqual(expectedName, actualTestName);
     }
 }

--- a/tests/trx2junit.Core.Tests/data/junit/xunit-datadriven.xml
+++ b/tests/trx2junit.Core.Tests/data/junit/xunit-datadriven.xml
@@ -2,20 +2,20 @@
 <testsuites>
     <testsuite name="XUnitSample.DataDriven" hostname="GFOIDL-PC-2018" package=".NET Core" id="0" tests="3" failures="1" errors="0" skipped="0" time="0.004" timestamp="2019-04-18T18:24:24">
         <properties />
-        <testcase name="XUnitSample.DataDriven.Two_pass_one_fails(arg: 0)" classname="XUnitSample.DataDriven" time="0.001" />
-        <testcase name="XUnitSample.DataDriven.Two_pass_one_fails(arg: 2)" classname="XUnitSample.DataDriven" time="0.002" />
-        <testcase name="XUnitSample.DataDriven.Two_pass_one_fails(arg: 1)" classname="XUnitSample.DataDriven" time="0.001">
+        <testcase name="Two_pass_one_fails(arg: 0)" classname="XUnitSample.DataDriven" time="0.001" />
+        <testcase name="Two_pass_one_fails(arg: 2)" classname="XUnitSample.DataDriven" time="0.002" />
+        <testcase name="Two_pass_one_fails(arg: 1)" classname="XUnitSample.DataDriven" time="0.001">
             <failure message="Failing for demo purposes&#xD;&#xA;Expected: True&#xD;&#xA;Actual:   False" type="not specified">   at XUnitSample.DataDriven.Two_pass_one_fails(Int32 arg) in D:\Work-Git\github\Mini\trx2junit\samples\XUnitSample\DataDriven.cs:line 17</failure>
         </testcase>
         <system-out />
         <system-err />
     </testsuite>
-    <testsuite name="XUnitSample" hostname="GFOIDL-PC-2018" package=".NET Core" id="1" tests="2" failures="1" errors="0" skipped="0" time="1.010" timestamp="2019-04-18T18:24:24">
+    <testsuite name="XUnitSample.DataDriven" hostname="GFOIDL-PC-2018" package=".NET Core" id="1" tests="2" failures="1" errors="0" skipped="0" time="1.010" timestamp="2019-04-18T18:24:24">
         <properties />
-        <testcase name="XUnitSample.DataDriven.Failing_test" classname="XUnitSample" time="0.003">
+        <testcase name="Failing_test" classname="XUnitSample.DataDriven" time="0.003">
             <failure message="Failing for demo purposes&#xD;&#xA;Expected: True&#xD;&#xA;Actual:   False" type="not specified">   at XUnitSample.DataDriven.Failing_test() in D:\Work-Git\github\Mini\trx2junit\samples\XUnitSample\DataDriven.cs:line 26</failure>
         </testcase>
-        <testcase name="XUnitSample.DataDriven.Slow_test" classname="XUnitSample" time="1.007" />
+        <testcase name="Slow_test" classname="XUnitSample.DataDriven" time="1.007" />
         <system-out />
         <system-err />
     </testsuite>

--- a/tests/trx2junit.Core.Tests/data/junit/xunit-ignore.xml
+++ b/tests/trx2junit.Core.Tests/data/junit/xunit-ignore.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-    <testsuite name="XUnitSample" hostname="GFOIDL-PC-2018" package=".NET Core" id="0" tests="4" failures="1" errors="0" skipped="1" time="1.028" timestamp="2019-04-19T16:10:34">
+    <testsuite name="XUnitSample.SimpleTests" hostname="GFOIDL-PC-2018" package=".NET Core" id="0" tests="4" failures="1" errors="0" skipped="1" time="1.028" timestamp="2019-04-19T16:10:34">
         <properties />
-        <testcase name="XUnitSample.SimpleTests.Passing_test" classname="XUnitSample" time="0.002" />
-        <testcase name="XUnitSample.SimpleTests.Failing_test" classname="XUnitSample" time="0.006">
+        <testcase name="Passing_test" classname="XUnitSample.SimpleTests" time="0.002" />
+        <testcase name="Failing_test" classname="XUnitSample.SimpleTests" time="0.006">
             <failure message="Failing for demo purposes&#xD;&#xA;Expected: True&#xD;&#xA;Actual:   False" type="not specified">   at XUnitSample.SimpleTests.Failing_test() in D:\Work-Git\github\Mini\trx2junit\samples\XUnitSample\SimpleTests.cs:line 20</failure>
         </testcase>
-        <testcase name="XUnitSample.SimpleTests.Slow_test" classname="XUnitSample" time="1.019" />
-        <testcase name="XUnitSample.SimpleTests.Ignored_test" classname="XUnitSample" time="0.001">
+        <testcase name="Slow_test" classname="XUnitSample.SimpleTests" time="1.019" />
+        <testcase name="Ignored_test" classname="XUnitSample.SimpleTests" time="0.001">
             <skipped />
         </testcase>
         <system-out />

--- a/tests/trx2junit.Core.Tests/data/junit/xunit-memberdata.xml
+++ b/tests/trx2junit.Core.Tests/data/junit/xunit-memberdata.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-    <testsuite name="XUnitSample" hostname="GFOIDL-PC-2018" package=".NET Core" id="0" tests="5" failures="2" errors="0" skipped="0" time="1.098" timestamp="2019-04-18T14:28:21">
+    <testsuite name="XUnitSample.MemberData" hostname="GFOIDL-PC-2018" package=".NET Core" id="0" tests="5" failures="2" errors="0" skipped="0" time="1.098" timestamp="2019-04-18T14:28:21">
         <properties />
-        <testcase name="XUnitSample.MemberData.Slow_test" classname="XUnitSample" time="1.015" />
-        <testcase name="XUnitSample.MemberData.Two_pass_one_fails(obj: { index = 0 })" classname="XUnitSample" time="0.072" />
-        <testcase name="XUnitSample.MemberData.Two_pass_one_fails(obj: { index = 1 })" classname="XUnitSample" time="0.001">
+        <testcase name="Slow_test" classname="XUnitSample.MemberData" time="1.015" />
+        <testcase name="Two_pass_one_fails(obj: { index = 0 })" classname="XUnitSample.MemberData" time="0.072" />
+        <testcase name="Two_pass_one_fails(obj: { index = 1 })" classname="XUnitSample.MemberData" time="0.001">
             <failure message="Failing for demo purposes&#xD;&#xA;Expected: True&#xD;&#xA;Actual:   False" type="not specified">   at XUnitSample.MemberData.Two_pass_one_fails(Object obj) in C:\code\trx2junit\samples\XUnitSample\MemberData.cs:line 23</failure>
         </testcase>
-        <testcase name="XUnitSample.MemberData.Two_pass_one_fails(obj: { index = 2 })" classname="XUnitSample" time="0.001" />
-        <testcase name="XUnitSample.MemberData.Failing_test" classname="XUnitSample" time="0.009">
+        <testcase name="Two_pass_one_fails(obj: { index = 2 })" classname="XUnitSample.MemberData" time="0.001" />
+        <testcase name="Failing_test" classname="XUnitSample.MemberData" time="0.009">
             <failure message="Failing for demo purposes&#xD;&#xA;Expected: True&#xD;&#xA;Actual:   False" type="not specified">   at XUnitSample.MemberData.Failing_test() in C:\code\trx2junit\samples\XUnitSample\MemberData.cs:line 32</failure>
         </testcase>
         <system-out />

--- a/tests/trx2junit.Core.Tests/data/junit/xunit.xml
+++ b/tests/trx2junit.Core.Tests/data/junit/xunit.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-    <testsuite name="XUnitSample" hostname="GFOIDL-PC-2018" package=".NET Core" id="0" tests="3" failures="1" errors="0" skipped="0" time="1.029" timestamp="2019-04-18T18:26:18">
+    <testsuite name="XUnitSample.SimpleTests" hostname="GFOIDL-PC-2018" package=".NET Core" id="0" tests="3" failures="1" errors="0" skipped="0" time="1.029" timestamp="2019-04-18T18:26:18">
         <properties />
-        <testcase name="XUnitSample.SimpleTests.Passing_test" classname="XUnitSample" time="0.002" />
-        <testcase name="XUnitSample.SimpleTests.Failing_test" classname="XUnitSample" time="0.011">
+        <testcase name="Passing_test" classname="XUnitSample.SimpleTests" time="0.002" />
+        <testcase name="Failing_test" classname="XUnitSample.SimpleTests" time="0.011">
             <failure message="Failing for demo purposes&#xD;&#xA;Expected: True&#xD;&#xA;Actual:   False" type="not specified">   at XUnitSample.SimpleTests.Failing_test() in D:\Work-Git\github\Mini\trx2junit\samples\XUnitSample\SimpleTests.cs:line 20</failure>
         </testcase>
-        <testcase name="XUnitSample.SimpleTests.Slow_test" classname="XUnitSample" time="1.016" />
+        <testcase name="Slow_test" classname="XUnitSample.SimpleTests" time="1.016" />
         <system-out />
         <system-err />
     </testsuite>

--- a/tests/trx2junit.Core.Tests/data/trx/xunit-datadriven.trx
+++ b/tests/trx2junit.Core.Tests/data/trx/xunit-datadriven.trx
@@ -32,23 +32,23 @@ Actual:   False</Message>
   <TestDefinitions>
     <UnitTest name="XUnitSample.DataDriven.Two_pass_one_fails(arg: 0)" storage="d:\work-git\github\mini\trx2junit\samples\xunitsample\bin\debug\netcoreapp2.1\xunitsample.dll" id="64cef5f2-ef71-a37c-f9df-3f03d7849295">
       <Execution id="af46d02b-bb1f-469c-ac47-a42dee2db394" />
-      <TestMethod codeBase="D:\Work-Git\github\Mini\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample.DataDriven" name="XUnitSample.DataDriven.Two_pass_one_fails(arg: 0)" />
+      <TestMethod codeBase="D:\Work-Git\github\Mini\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample.DataDriven" name="Two_pass_one_fails" />
     </UnitTest>
     <UnitTest name="XUnitSample.DataDriven.Two_pass_one_fails(arg: 2)" storage="d:\work-git\github\mini\trx2junit\samples\xunitsample\bin\debug\netcoreapp2.1\xunitsample.dll" id="e73bdfc4-d932-676a-10b0-66bc277da6a8">
       <Execution id="bb2de31e-d978-446a-b43c-e6418abae839" />
-      <TestMethod codeBase="D:\Work-Git\github\Mini\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample.DataDriven" name="XUnitSample.DataDriven.Two_pass_one_fails(arg: 2)" />
+      <TestMethod codeBase="D:\Work-Git\github\Mini\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample.DataDriven" name="Two_pass_one_fails" />
     </UnitTest>
     <UnitTest name="XUnitSample.DataDriven.Failing_test" storage="d:\work-git\github\mini\trx2junit\samples\xunitsample\bin\debug\netcoreapp2.1\xunitsample.dll" id="932cdb9b-c6e1-1aa1-ab25-7b1cf6c0a872">
       <Execution id="fea82688-b00a-4962-a87a-716691cb7218" />
-      <TestMethod codeBase="D:\Work-Git\github\Mini\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample" name="XUnitSample.DataDriven.Failing_test" />
+      <TestMethod codeBase="D:\Work-Git\github\Mini\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample.DataDriven" name="Failing_test" />
     </UnitTest>
     <UnitTest name="XUnitSample.DataDriven.Two_pass_one_fails(arg: 1)" storage="d:\work-git\github\mini\trx2junit\samples\xunitsample\bin\debug\netcoreapp2.1\xunitsample.dll" id="5ae19c2c-bf9f-b890-d75d-5c6348c55337">
       <Execution id="17fb6c16-a755-4cd4-b597-25f95b78ed75" />
-      <TestMethod codeBase="D:\Work-Git\github\Mini\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample.DataDriven" name="XUnitSample.DataDriven.Two_pass_one_fails(arg: 1)" />
+      <TestMethod codeBase="D:\Work-Git\github\Mini\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample.DataDriven" name="Two_pass_one_fails" />
     </UnitTest>
     <UnitTest name="XUnitSample.DataDriven.Slow_test" storage="d:\work-git\github\mini\trx2junit\samples\xunitsample\bin\debug\netcoreapp2.1\xunitsample.dll" id="ef17caa0-0b32-c82d-88c3-ad7c5b73824f">
       <Execution id="21534ce9-b4be-4e6b-817f-563f14c8bc32" />
-      <TestMethod codeBase="D:\Work-Git\github\Mini\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample" name="XUnitSample.DataDriven.Slow_test" />
+      <TestMethod codeBase="D:\Work-Git\github\Mini\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample.DataDriven" name="Slow_test" />
     </UnitTest>
   </TestDefinitions>
   <TestEntries>

--- a/tests/trx2junit.Core.Tests/data/trx/xunit-ignore.trx
+++ b/tests/trx2junit.Core.Tests/data/trx/xunit-ignore.trx
@@ -26,19 +26,19 @@ Actual:   False</Message>
   <TestDefinitions>
     <UnitTest name="XUnitSample.SimpleTests.Passing_test" storage="d:\work-git\github\mini\trx2junit\samples\xunitsample\bin\debug\netcoreapp2.1\xunitsample.dll" id="42b9dabc-50e2-3260-1c97-693f92e48a53">
       <Execution id="716ff25d-92a8-414f-9f5c-a2f824d5036d" />
-      <TestMethod codeBase="D:\Work-Git\github\Mini\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample" name="XUnitSample.SimpleTests.Passing_test" />
+      <TestMethod codeBase="D:\Work-Git\github\Mini\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample.SimpleTests" name="Passing_test" />
     </UnitTest>
     <UnitTest name="XUnitSample.SimpleTests.Failing_test" storage="d:\work-git\github\mini\trx2junit\samples\xunitsample\bin\debug\netcoreapp2.1\xunitsample.dll" id="a4165991-a2d3-ed8e-00f3-f06b70f63c88">
       <Execution id="200426b3-eb18-4228-9770-78a4896d9f2f" />
-      <TestMethod codeBase="D:\Work-Git\github\Mini\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample" name="XUnitSample.SimpleTests.Failing_test" />
+      <TestMethod codeBase="D:\Work-Git\github\Mini\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample.SimpleTests" name="Failing_test" />
     </UnitTest>
     <UnitTest name="XUnitSample.SimpleTests.Slow_test" storage="d:\work-git\github\mini\trx2junit\samples\xunitsample\bin\debug\netcoreapp2.1\xunitsample.dll" id="95861539-7453-81f4-6db1-004fdd320efb">
       <Execution id="c99d70e9-7e43-48b2-95e9-758d8b91aa15" />
-      <TestMethod codeBase="D:\Work-Git\github\Mini\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample" name="XUnitSample.SimpleTests.Slow_test" />
+      <TestMethod codeBase="D:\Work-Git\github\Mini\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample.SimpleTests" name="Slow_test" />
     </UnitTest>
     <UnitTest name="XUnitSample.SimpleTests.Ignored_test" storage="d:\work-git\github\mini\trx2junit\samples\xunitsample\bin\debug\netcoreapp2.1\xunitsample.dll" id="225b4b67-b8e8-e001-c45d-3af5a6c71572">
       <Execution id="59022a90-b9de-4ad5-b4b7-7fd3f809a8b5" />
-      <TestMethod codeBase="D:\Work-Git\github\Mini\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample" name="XUnitSample.SimpleTests.Ignored_test" />
+      <TestMethod codeBase="D:\Work-Git\github\Mini\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample.SimpleTests" name="Ignored_test" />
     </UnitTest>
   </TestDefinitions>
   <TestEntries>

--- a/tests/trx2junit.Core.Tests/data/trx/xunit-memberdata.trx
+++ b/tests/trx2junit.Core.Tests/data/trx/xunit-memberdata.trx
@@ -32,15 +32,15 @@ Actual:   False</Message>
   <TestDefinitions>
     <UnitTest name="XUnitSample.MemberData.Slow_test" storage="C:\code\trx2junit\samples\xunitsample\bin\debug\netcoreapp2.1\xunitsample.dll" id="a6e017b4-8b60-1f4f-14a2-c4fb102fe07d">
       <Execution id="3fb78887-e130-4364-9047-ca0f9262a0a4" />
-      <TestMethod codeBase="C:\code\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample" name="XUnitSample.MemberData.Slow_test" />
+      <TestMethod codeBase="C:\code\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample.MemberData" name="Slow_test" />
     </UnitTest>
     <UnitTest name="XUnitSample.MemberData.Two_pass_one_fails" storage="C:\code\trx2junit\samples\xunitsample\bin\debug\netcoreapp2.1\xunitsample.dll" id="452d3fa6-0698-f56d-5449-2587f368ee57">
       <Execution id="501e96a4-0f97-4381-9a72-465ada88ee45" />
-      <TestMethod codeBase="C:\code\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample" name="XUnitSample.MemberData.Two_pass_one_fails" />
+      <TestMethod codeBase="C:\code\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample.MemberData" name="Two_pass_one_fails" />
     </UnitTest>
     <UnitTest name="XUnitSample.MemberData.Failing_test" storage="C:\code\trx2junit\samples\xunitsample\bin\debug\netcoreapp2.1\xunitsample.dll" id="5eb02706-c05c-c61c-b55d-e0cf11c1ff83">
       <Execution id="ec8b6eba-e603-43ed-9343-285865038428" />
-      <TestMethod codeBase="C:\code\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample" name="XUnitSample.MemberData.Failing_test" />
+      <TestMethod codeBase="C:\code\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample.MemberData" name="Failing_test" />
     </UnitTest>
   </TestDefinitions>
   <TestEntries>

--- a/tests/trx2junit.Core.Tests/data/trx/xunit.trx
+++ b/tests/trx2junit.Core.Tests/data/trx/xunit.trx
@@ -21,15 +21,15 @@ Actual:   False</Message>
   <TestDefinitions>
     <UnitTest name="XUnitSample.SimpleTests.Passing_test" storage="d:\work-git\github\mini\trx2junit\samples\xunitsample\bin\debug\netcoreapp2.1\xunitsample.dll" id="42b9dabc-50e2-3260-1c97-693f92e48a53">
       <Execution id="e867ef4d-9d8e-4f02-8668-e90a4ca567f7" />
-      <TestMethod codeBase="D:\Work-Git\github\Mini\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample" name="XUnitSample.SimpleTests.Passing_test" />
+      <TestMethod codeBase="D:\Work-Git\github\Mini\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample.SimpleTests" name="Passing_test" />
     </UnitTest>
     <UnitTest name="XUnitSample.SimpleTests.Failing_test" storage="d:\work-git\github\mini\trx2junit\samples\xunitsample\bin\debug\netcoreapp2.1\xunitsample.dll" id="a4165991-a2d3-ed8e-00f3-f06b70f63c88">
       <Execution id="38a4e0f9-bf04-458f-8cb2-a7a3070f6732" />
-      <TestMethod codeBase="D:\Work-Git\github\Mini\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample" name="XUnitSample.SimpleTests.Failing_test" />
+      <TestMethod codeBase="D:\Work-Git\github\Mini\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample.SimpleTests" name="Failing_test" />
     </UnitTest>
     <UnitTest name="XUnitSample.SimpleTests.Slow_test" storage="d:\work-git\github\mini\trx2junit\samples\xunitsample\bin\debug\netcoreapp2.1\xunitsample.dll" id="95861539-7453-81f4-6db1-004fdd320efb">
       <Execution id="f97fc76e-0577-4720-bebc-aa62a9216b1c" />
-      <TestMethod codeBase="D:\Work-Git\github\Mini\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample" name="XUnitSample.SimpleTests.Slow_test" />
+      <TestMethod codeBase="D:\Work-Git\github\Mini\trx2junit\samples\XUnitSample\bin\Debug\netcoreapp2.1\XUnitSample.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="XUnitSample.SimpleTests" name="Slow_test" />
     </UnitTest>
   </TestDefinitions>
   <TestEntries>


### PR DESCRIPTION
XUnit may write the full-qualified name as the `testName`, but for (Jenkins) JUnit this is expected to be only the test-name (i.e. not fully-qualified), as there's also the `className` which is fully-qualified.

Fixes https://github.com/gfoidl/trx2junit/issues/102