### PR TITLE
Timestamps honor timezone

### DIFF
--- a/source/trx2junit.Core/Extensions/TimeExtensions.cs
+++ b/source/trx2junit.Core/Extensions/TimeExtensions.cs
@@ -23,7 +23,7 @@ internal static class TimeExtensions
         return string.Create(19, dt, static (buffer, value) => FormatDateTime(buffer, value));
     }
     //-------------------------------------------------------------------------
-    public static string ToTrxDateTime(this DateTime dt)
+    public static string ToTrxDateTime(this DateTimeOffset dt)
     {
         dt = dt.ToUniversalTime();
 
@@ -39,7 +39,7 @@ internal static class TimeExtensions
     //-------------------------------------------------------------------------
     public static string ToJUnitTime(this double value) => value.ToString("0.000", CultureInfo.InvariantCulture);
     //-------------------------------------------------------------------------
-    public static DateTime? ParseDateTime(this string value)
+    public static DateTimeOffset? ParseDateTime(this string value)
     {
         ReadOnlySpan<char> span = value.AsSpan();
 
@@ -71,7 +71,7 @@ internal static class TimeExtensions
             }
 
             int millisecond           = 0;
-            DateTimeKind dateTimeKind = DateTimeKind.Local;
+            DateTimeKind dateTimeKind = DateTimeKind.Utc;
 
             if (value.Length == 29)
             {
@@ -109,6 +109,12 @@ internal static class TimeExtensions
         {
             FormatDateTimeScalar(buffer, value);
         }
+    }
+    //-------------------------------------------------------------------------
+    private static void FormatDateTime(Span<char> buffer, DateTimeOffset value)
+    {
+        // TODO: fix
+        throw new NotImplementedException();
     }
     //-------------------------------------------------------------------------
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/source/trx2junit.Core/Extensions/XElementExtensions.cs
+++ b/source/trx2junit.Core/Extensions/XElementExtensions.cs
@@ -8,7 +8,7 @@ namespace gfoidl.Trx2Junit.Core;
 
 internal static class XElementExtensions
 {
-    public static DateTime? ReadDateTime(this XElement element, string attributeName)
+    public static DateTimeOffset? ReadDateTime(this XElement element, string attributeName)
     {
         string? value = (string?)element.Attribute(attributeName);
         return value!.ParseDateTime();
@@ -68,7 +68,7 @@ internal static class XElementExtensions
         return true;
     }
     //-------------------------------------------------------------------------
-    public static bool WriteTrxDateTime(this XElement element, string attributeName, DateTime? value)
+    public static bool WriteTrxDateTime(this XElement element, string attributeName, DateTimeOffset? value)
     {
         if (!value.HasValue) return false;
 

--- a/source/trx2junit.Core/Internal/junit2trx/JUnitTestResultXmlParser.cs
+++ b/source/trx2junit.Core/Internal/junit2trx/JUnitTestResultXmlParser.cs
@@ -52,7 +52,7 @@ internal sealed class JUnitTestResultXmlParser : ITestResultXmlParser<JUnitTest>
             FailureCount  = xTestSuite.ReadInt("failures"),
             SkippedCount  = xTestSuite.ReadInt("skipped"),
             TimeInSeconds = xTestSuite.ReadDouble("time"),
-            TimeStamp     = xTestSuite.ReadDateTime("timestamp")!.Value,
+            TimeStamp     = xTestSuite.ReadDateTime("timestamp")!.Value.UtcDateTime
         };
 
         int? testCount = xTestSuite.ReadInt("tests");

--- a/source/trx2junit.Core/Internal/trx2junit/Trx2JunitTestConverter.cs
+++ b/source/trx2junit.Core/Internal/trx2junit/Trx2JunitTestConverter.cs
@@ -61,7 +61,7 @@ internal sealed class Trx2JunitTestConverter : ITestConverter<TrxTest, JUnitTest
 
         if (_counters.TimeStamp.HasValue)
         {
-            testSuite.TimeStamp = _counters.TimeStamp.Value;
+            testSuite.TimeStamp = _counters.TimeStamp.Value.UtcDateTime;
         }
     }
     //-------------------------------------------------------------------------
@@ -118,13 +118,13 @@ internal sealed class Trx2JunitTestConverter : ITestConverter<TrxTest, JUnitTest
     //-------------------------------------------------------------------------
     private struct Counters
     {
-        public int       TestCount;
-        public int       Failures;
+        public int             TestCount;
+        public int             Failures;
 #pragma warning disable CS0649
-        public int       Errors;
+        public int             Errors;
 #pragma warning restore CS0649
-        public int       Skipped;
-        public TimeSpan  Time;
-        public DateTime? TimeStamp;
+        public int             Skipped;
+        public TimeSpan        Time;
+        public DateTimeOffset? TimeStamp;
     }
 }

--- a/source/trx2junit.Core/Models/Trx/TrxTimes.cs
+++ b/source/trx2junit.Core/Models/Trx/TrxTimes.cs
@@ -6,10 +6,10 @@ namespace gfoidl.Trx2Junit.Core.Models.Trx;
 
 internal sealed class TrxTimes
 {
-    public DateTime? Creation { get; set; }
-    public DateTime? Queuing  { get; set; }
-    public DateTime? Start    { get; set; }
-    public DateTime? Finish   { get; set; }
+    public DateTimeOffset? Creation { get; set; }
+    public DateTimeOffset? Queuing  { get; set; }
+    public DateTimeOffset? Start    { get; set; }
+    public DateTimeOffset? Finish   { get; set; }
     //-------------------------------------------------------------------------
     public TimeSpan? RunTime => this.Finish - this.Creation;
 }

--- a/source/trx2junit.Core/Models/Trx/TrxUnitTestResult.cs
+++ b/source/trx2junit.Core/Models/Trx/TrxUnitTestResult.cs
@@ -6,16 +6,16 @@ namespace gfoidl.Trx2Junit.Core.Models.Trx;
 
 internal sealed class TrxUnitTestResult
 {
-    public Guid        ExecutionId  { get; set; }
-    public Guid        TestId       { get; set; }
-    public string?     TestName     { get; set; }
-    public TimeSpan?   Duration     { get; set; }
-    public DateTime?   StartTime    { get; set; }
-    public DateTime?   EndTime      { get; set; }
-    public TrxOutcome? Outcome      { get; set; }
-    public string?     ComputerName { get; set; }
-    public string?     Message      { get; set; }
-    public string?     StackTrace   { get; set; }
-    public string?     StdOut       { get; set; }
-    public string?     StdErr       { get; set; }
+    public Guid            ExecutionId  { get; set; }
+    public Guid            TestId       { get; set; }
+    public string?         TestName     { get; set; }
+    public TimeSpan?       Duration     { get; set; }
+    public DateTimeOffset? StartTime    { get; set; }
+    public DateTimeOffset? EndTime      { get; set; }
+    public TrxOutcome?     Outcome      { get; set; }
+    public string?         ComputerName { get; set; }
+    public string?         Message      { get; set; }
+    public string?         StackTrace   { get; set; }
+    public string?         StdOut       { get; set; }
+    public string?         StdErr       { get; set; }
 }

--- a/tests/trx2junit.Core.Tests/Extensions/TimeExtensionsTests/ParseDateTime.cs
+++ b/tests/trx2junit.Core.Tests/Extensions/TimeExtensionsTests/ParseDateTime.cs
@@ -11,10 +11,10 @@ public class ParseDateTime
     [Test]
     public void Valid_JUnitDateTime___OK()
     {
-        DateTime now = new DateTime(2019, 11, 10, 15, 33, 27);
-        string value = now.ToJUnitDateTime();
+        DateTimeOffset now = new(2019, 11, 10, 15, 33, 27, TimeSpan.FromHours(1d));
+        string value       = now.UtcDateTime.ToJUnitDateTime();
 
-        DateTime? actual = value.ParseDateTime();
+        DateTimeOffset? actual = value.ParseDateTime();
 
         Assert.Multiple(() =>
         {
@@ -36,10 +36,10 @@ public class ParseDateTime
             {
                 for (int second = 0; second < 60; ++second)
                 {
-                    DateTime dt  = new DateTime(year, month, day, hour, minute, second);
-                    string value = dt.ToJUnitDateTime();
+                    DateTimeOffset dt = new(year, month, day, hour, minute, second, TimeSpan.FromHours(1d));
+                    string value      = dt.UtcDateTime.ToJUnitDateTime();
 
-                    DateTime? actual = value.ParseDateTime();
+                    DateTimeOffset? actual = value.ParseDateTime();
 
                     Assert.Multiple(() =>
                     {
@@ -54,16 +54,15 @@ public class ParseDateTime
     [Test]
     public void Valid_TrxDateTime___OK()
     {
-        DateTime now = new(2019, 11, 10, 15, 33, 27, 123);
-        string value = now.ToTrxDateTime();
+        DateTimeOffset now = new(2019, 11, 10, 15, 33, 27, 123, TimeSpan.FromHours(1d));
+        string value       = now.ToTrxDateTime();
 
-        DateTime? actual = value.ParseDateTime();
+        DateTimeOffset? actual = value.ParseDateTime();
 
         Assert.Multiple(() =>
         {
             Assert.IsTrue(actual.HasValue);
-            Assert.AreEqual(now.ToUniversalTime(), actual.Value);
-            Assert.AreEqual(DateTimeKind.Utc, actual.Value.Kind);
+            Assert.AreEqual(now, actual.Value);
         });
     }
     //-------------------------------------------------------------------------
@@ -75,7 +74,7 @@ public class ParseDateTime
     [TestCase("201a-11-17T12:26:07")]
     public void Invalid_DateTime_string___null(string value)
     {
-        DateTime? actual = value.ParseDateTime();
+        DateTimeOffset? actual = value.ParseDateTime();
 
         Assert.IsFalse(actual.HasValue, "actual = {0}", actual);
     }

--- a/tests/trx2junit.Core.Tests/Extensions/TimeExtensionsTests/ToTrxDateTime.cs
+++ b/tests/trx2junit.Core.Tests/Extensions/TimeExtensionsTests/ToTrxDateTime.cs
@@ -10,13 +10,15 @@ namespace gfoidl.Trx2Junit.Core.Tests.Extensions.TimeExtensionsTests;
 public class ToTrxDateTime
 {
     [Test, TestCaseSource(nameof(DateTime_given___correct_format_TestCases))]
-    public string DateTime_given___correct_format(DateTime dateTime)
+    public string DateTime_given___correct_format(DateTimeOffset dateTime)
     {
         return dateTime.ToTrxDateTime();
     }
     //-------------------------------------------------------------------------
     private static IEnumerable<TestCaseData> DateTime_given___correct_format_TestCases()
     {
-        yield return new TestCaseData(new DateTime(2019, 11, 10, 15, 33, 27, 446, DateTimeKind.Utc)).Returns("2019-11-10T15:33:27.446+00:00");
+        yield return new TestCaseData(new DateTimeOffset(2019, 11, 10, 15, 33, 27, 446, TimeSpan.FromHours(0d))).Returns("2019-11-10T15:33:27.446+00:00");
+        yield return new TestCaseData(new DateTimeOffset(2019, 11, 10, 15, 33, 27, 446, TimeSpan.FromHours(1d))).Returns("2019-11-10T15:33:27.446+01:00");
+        yield return new TestCaseData(new DateTimeOffset(2019, 11, 10, 15, 33, 27, 446, TimeSpan.FromHours(2d))).Returns("2019-11-10T15:33:27.446+02:00");
     }
 }

--- a/tests/trx2junit.Core.Tests/Extensions/XElementExtensionsTests/ReadDateTime.cs
+++ b/tests/trx2junit.Core.Tests/Extensions/XElementExtensionsTests/ReadDateTime.cs
@@ -12,10 +12,10 @@ public class ReadDateTime
     [Test]
     public void Xml_with_valid_DateTime_given___OK()
     {
-        DateTime now = new DateTime(2019, 11, 10, 15, 33, 27);
-        var xml      = new XElement("data", new XAttribute("dt", now.ToJUnitDateTime()));
+        DateTimeOffset now = new(2019, 11, 10, 15, 33, 27, TimeSpan.FromHours(1d));
+        var xml            = new XElement("data", new XAttribute("dt", now.UtcDateTime.ToJUnitDateTime()));
 
-        DateTime? actual = xml.ReadDateTime("dt");
+        DateTimeOffset? actual = xml.ReadDateTime("dt");
 
         Assert.Multiple(() =>
         {
@@ -29,7 +29,7 @@ public class ReadDateTime
     {
         var xml = new XElement("data", new XAttribute("foo", "123"));
 
-        DateTime? actual = xml.ReadDateTime("foo");
+        DateTimeOffset? actual = xml.ReadDateTime("foo");
 
         Assert.IsFalse(actual.HasValue);
     }
@@ -39,7 +39,7 @@ public class ReadDateTime
     {
         var xml = new XElement("data");
 
-        DateTime? actual = xml.ReadDateTime("foo");
+        DateTimeOffset? actual = xml.ReadDateTime("foo");
 
         Assert.IsFalse(actual.HasValue);
     }

--- a/tests/trx2junit.Core.Tests/Extensions/XElementExtensionsTests/WriteTrxDateTime.cs
+++ b/tests/trx2junit.Core.Tests/Extensions/XElementExtensionsTests/WriteTrxDateTime.cs
@@ -24,9 +24,9 @@ public class WriteTrxDateTime
     [Test]
     public void Non_null_given___attribute_added()
     {
-        DateTime? value = DateTime.Now;
-        var xmlExpected = new XElement("root", new XAttribute("dt", value.Value.ToTrxDateTime()));
-        var xml         = new XElement("root");
+        DateTimeOffset? value = DateTimeOffset.Now;
+        var xmlExpected       = new XElement("root", new XAttribute("dt", value.Value.ToTrxDateTime()));
+        var xml               = new XElement("root");
 
         xml.WriteTrxDateTime("dt", value);
 

--- a/tests/trx2junit.Core.Tests/Internal/JUnit2TrxTestConverterTests/SetCreationTimestamp.cs
+++ b/tests/trx2junit.Core.Tests/Internal/JUnit2TrxTestConverterTests/SetCreationTimestamp.cs
@@ -15,30 +15,30 @@ public class SetCreationTimestamp
     public void TrxTimes_Creation_is_null___TimeStamp_set()
     {
         var trxTimes       = new TrxTimes();
-        var junitTestSuite = new JUnitTestSuite { TimeStamp = DateTime.Now };
+        var junitTestSuite = new JUnitTestSuite { TimeStamp = DateTimeOffset.Now.UtcDateTime };
 
         JUnit2TrxTestConverter.SetCreationTimestamp(junitTestSuite, trxTimes);
 
-        Assert.AreEqual(junitTestSuite.TimeStamp, trxTimes.Creation);
+        Assert.AreEqual(junitTestSuite.TimeStamp, trxTimes.Creation.Value.UtcDateTime);
     }
     //-------------------------------------------------------------------------
     [Test]
     public void TrxTimes_Creation_has_value_TimeStamp_is_smaller___TimeStamp_set()
     {
-        var trxTimes       = new TrxTimes       { Creation  = DateTime.Now };
-        var junitTestSuite = new JUnitTestSuite { TimeStamp = DateTime.Now.AddSeconds(-1) };
+        var trxTimes       = new TrxTimes       { Creation  = DateTimeOffset.Now };
+        var junitTestSuite = new JUnitTestSuite { TimeStamp = DateTimeOffset.Now.UtcDateTime.AddSeconds(-1) };
 
         JUnit2TrxTestConverter.SetCreationTimestamp(junitTestSuite, trxTimes);
 
-        Assert.AreEqual(junitTestSuite.TimeStamp, trxTimes.Creation.Value);
+        Assert.AreEqual(junitTestSuite.TimeStamp, trxTimes.Creation.Value.UtcDateTime);
     }
     //-------------------------------------------------------------------------
     [Test]
     public void TrxTimes_Creation_has_value_TimeStamp_is_greater___nop()
     {
-        DateTime now       = DateTime.Now;
+        DateTimeOffset now = DateTimeOffset.Now;
         var trxTimes       = new TrxTimes       { Creation  = now };
-        var junitTestSuite = new JUnitTestSuite { TimeStamp = DateTime.Now.AddSeconds(1) };
+        var junitTestSuite = new JUnitTestSuite { TimeStamp = DateTimeOffset.Now.UtcDateTime.AddSeconds(1) };
 
         JUnit2TrxTestConverter.SetCreationTimestamp(junitTestSuite, trxTimes);
 


### PR DESCRIPTION
Fixes https://github.com/gfoidl/trx2junit/issues/105

Unfortunately JUnit doesn't specify which timezone the timestamps are in, and according the xml-schema the tz-info can't be stored. Thus timestamps for Junit are assumed to be in UTC.

Trx has tz-info, so when they are converted to JUnit-xml, the emitted timestamps are written as UTC-timestamps.

For `--junit2trx`-conversion the JUnit-timestamp is treated as UTC.

