### PR TITLE
Opt-in to emit error message in CDATA-element of failure-element

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -54,6 +54,9 @@ This can be configured via environment varialbes (note: if omitted, the default 
 | failure | `TRX2JUNIT_JENKINS_TESTCASE_STATUS_FAILURE` | `0`           |
 | skipped | `TRX2JUNIT_JENKINS_TESTCASE_STATUS_SKIPPED` | not set       |
 
+With environment variable `TRX2JUNIT_JUNIT_ERROR_MESSAGE_IN_CDATA` set, the error message from a failing test will be repeated in the _CDATA_-content of the `<failure>` element.
+See [this comment](https://github.com/gfoidl/trx2junit/issues/104#issuecomment-1178852241) for further info.
+
 ### junit to trx
 
 With option `--junit2trx` a conversion from _junit_ to _trx_ can be performed.

--- a/source/trx2junit.Core/Globals.cs
+++ b/source/trx2junit.Core/Globals.cs
@@ -6,10 +6,11 @@ namespace gfoidl.Trx2Junit.Core;
 
 internal static class Globals
 {
-    public static readonly string  JUnitTestCaseStatusSuccess = GetEnvironmentVariable("TRX2JUNIT_JENKINS_TESTCASE_STATUS_SUCCESS") ?? "1";
-    public static readonly string  JUnitTestCaseStatusFailure = GetEnvironmentVariable("TRX2JUNIT_JENKINS_TESTCASE_STATUS_FAILURE") ?? "0";
-    public static readonly string? JUnitTestCaseStatusSkipped = GetEnvironmentVariable("TRX2JUNIT_JENKINS_TESTCASE_STATUS_SKIPPED");
-    public static readonly bool    VectorsEnabled             = GetEnvironmentVariable("TRX2JUNIT_VECTORS_ENABLED") != null;
+    public static readonly string  JUnitTestCaseStatusSuccess   = GetEnvironmentVariable("TRX2JUNIT_JENKINS_TESTCASE_STATUS_SUCCESS") ?? "1";
+    public static readonly string  JUnitTestCaseStatusFailure   = GetEnvironmentVariable("TRX2JUNIT_JENKINS_TESTCASE_STATUS_FAILURE") ?? "0";
+    public static readonly string? JUnitTestCaseStatusSkipped   = GetEnvironmentVariable("TRX2JUNIT_JENKINS_TESTCASE_STATUS_SKIPPED");
+    public static readonly bool    JUnitErrorMessageRepeatCData = GetEnvironmentVariable("TRX2JUNIT_JUNIT_ERROR_MESSAGE_IN_CDATA") != null;
+    public static readonly bool    VectorsEnabled               = GetEnvironmentVariable("TRX2JUNIT_VECTORS_ENABLED") != null;
     //---------------------------------------------------------------------
     private static string? GetEnvironmentVariable(string envVariableName)
     {

--- a/source/trx2junit.Core/Internal/trx2junit/JUnitTestResultXmlBuilder.cs
+++ b/source/trx2junit.Core/Internal/trx2junit/JUnitTestResultXmlBuilder.cs
@@ -94,14 +94,21 @@ internal sealed class JUnitTestResultXmlBuilder : ITestResultXmlBuilder<JUnitTes
         }
         else if (testCase.Error != null)
         {
-            string failureContent = $"{testCase.Error.Message}\n{testCase.Error.StackTrace?.TrimEnd()}";
+            string? failureContent = Globals.JUnitErrorMessageRepeatCData
+                ? $"{testCase.Error.Message}\n{testCase.Error.StackTrace?.TrimEnd()}"
+                : testCase.Error.StackTrace?.TrimEnd();
 
-            xTestCase.Add(new XElement("failure",
-                new XCData(failureContent),
+            XElement xFailure = new ("failure",
                 new XAttribute("message", testCase.Error.Message!),
                 new XAttribute("type"   , testCase.Error.Type!)
-            ));
+            );
 
+            if (failureContent is not null)
+            {
+                xFailure.Add(new XCData(failureContent));
+            }
+
+            xTestCase.Add(xFailure);
             xTestCase.Add(new XAttribute("status", Globals.JUnitTestCaseStatusFailure));
         }
         else

--- a/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Integration.cs
+++ b/tests/trx2junit.Core.Tests/Internal/JUnitTestResultXmlBuilderTests/Integration.cs
@@ -74,8 +74,7 @@ public class Integration
         {
             Assert.AreEqual("Failing for demo purposes", failure.Attribute("message").Value);
 
-            string expectedContent = @"<![CDATA[Failing for demo purposes
-   at NUnitSample.SimpleTests.Failing_test() in D:\Work-Git\github\Mini\trx2junit\samples\NUnitSample\SimpleTests.cs:line 21]]>";
+            string expectedContent = @"<![CDATA[   at NUnitSample.SimpleTests.Failing_test() in D:\Work-Git\github\Mini\trx2junit\samples\NUnitSample\SimpleTests.cs:line 21]]>";
             string actualContent   = failure.LastNode.ToString();
 
             expectedContent = NormalizeLineEndings(expectedContent);


### PR DESCRIPTION
Fixes https://github.com/gfoidl/trx2junit/issues/104 (point 2)
Cf. https://github.com/gfoidl/trx2junit/issues/104#issuecomment-1178852241 for more context.

Default is now to not emit the error message in the CDATA-element.
This can be opted-in by setting the environment variable `TRX2JUNIT_JUNIT_ERROR_MESSAGE_IN_CDATA` to any value.