### PR TITLE
Fixed testcase names with `.` in arguments

### DIFF
--- a/source/trx2junit.Core/Internal/TypeInfoHelper.cs
+++ b/source/trx2junit.Core/Internal/TypeInfoHelper.cs
@@ -1,5 +1,6 @@
 // (c) gfoidl, all rights reserved
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace gfoidl.Trx2Junit.Core;
@@ -11,12 +12,53 @@ internal static class TypeInfoHelper
     {
         if (name is null) return null;
 
+        ReadOnlySpan<char> span = name;
+
+        int parenthesisIndex = span.IndexOf('(');
+        if (parenthesisIndex < 0)
+        {
+            return StripTypeInfo(span).ToString();
+        }
+
+        ReadOnlySpan<char> preParenthesis   = span.Slice(0, parenthesisIndex);
+        ReadOnlySpan<char> parenthisContent = span.Slice(parenthesisIndex);
+
+        preParenthesis = StripTypeInfo(preParenthesis);
+
+#if NET6_0_OR_GREATER
+        return string.Concat(preParenthesis, parenthisContent);
+#else
+        int finalLength = preParenthesis.Length + parenthisContent.Length;
+        unsafe
+        {
+            fixed (char* ptr0 = preParenthesis)
+            fixed (char* ptr1 = parenthisContent)
+            {
+                return string.Create(
+                    finalLength,
+                    ((IntPtr)ptr0, preParenthesis.Length, (IntPtr)ptr1, parenthisContent.Length),
+                    static (buffer, state) =>
+                    {
+                        ReadOnlySpan<char> s0 = new(state.Item1.ToPointer(), state.Item2);
+                        ReadOnlySpan<char> s1 = new(state.Item3.ToPointer(), state.Item4);
+
+                        s0.CopyTo(buffer);
+                        s1.CopyTo(buffer.Slice(s0.Length));
+                    }
+                );
+            }
+        }
+#endif
+    }
+    //-------------------------------------------------------------------------
+    private static ReadOnlySpan<char> StripTypeInfo(ReadOnlySpan<char> name)
+    {
         int idx = name.LastIndexOf('.');
         if (idx < 0)
         {
             return name;
         }
 
-        return name[(idx + 1)..];
+        return name.Slice(idx + 1);
     }
 }

--- a/source/trx2junit.Core/Internal/TypeInfoHelper.cs
+++ b/source/trx2junit.Core/Internal/TypeInfoHelper.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace gfoidl.Trx2Junit.Core;
 
-internal static class StringExtensions
+internal static class TypeInfoHelper
 {
     [return: NotNullIfNotNull("name")]
     public static string? StripTypeInfo(this string? name)

--- a/source/trx2junit.Core/trx2junit.Core.csproj
+++ b/source/trx2junit.Core/trx2junit.Core.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
         <RootNamespace>gfoidl.Trx2Junit.Core</RootNamespace>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tests/trx2junit.Core.Tests/Internal/TypeInfoHelperTests/StripTypeInfo.cs
+++ b/tests/trx2junit.Core.Tests/Internal/TypeInfoHelperTests/StripTypeInfo.cs
@@ -19,13 +19,19 @@ public class StripTypeInfo
         yield return new TestCaseData(null).Returns(null);
         yield return new TestCaseData("").Returns("");
 
-        yield return new TestCaseData("Method1").Returns("Method1");
+        yield return new TestCaseData("Method1")                .Returns("Method1");
         yield return new TestCaseData("Method1(arg: { a = 3 })").Returns("Method1(arg: { a = 3 })");
+        yield return new TestCaseData("Method1(3.14)")          .Returns("Method1(3.14)");
+        yield return new TestCaseData("Method1(3.14, 2.72)")    .Returns("Method1(3.14, 2.72)");
 
-        yield return new TestCaseData("Class1.Method1").Returns("Method1");
+        yield return new TestCaseData("Class1.Method1")                .Returns("Method1");
         yield return new TestCaseData("Class1.Method1(arg: { a = 3 })").Returns("Method1(arg: { a = 3 })");
+        yield return new TestCaseData("Class1.Method1(3.14)")          .Returns("Method1(3.14)");
+        yield return new TestCaseData("Class1.Method1(3.14, 2.72)")    .Returns("Method1(3.14, 2.72)");
 
-        yield return new TestCaseData("SimpleUnitTest.Class1.Method1").Returns("Method1");
+        yield return new TestCaseData("SimpleUnitTest.Class1.Method1")                .Returns("Method1");
         yield return new TestCaseData("SimpleUnitTest.Class1.Method1(arg: { a = 3 })").Returns("Method1(arg: { a = 3 })");
+        yield return new TestCaseData("SimpleUnitTest.Class1.Method1(3.14)")          .Returns("Method1(3.14)");
+        yield return new TestCaseData("SimpleUnitTest.Class1.Method1(3.14, 2.72)")    .Returns("Method1(3.14, 2.72)");
     }
 }

--- a/tests/trx2junit.Core.Tests/Internal/TypeInfoHelperTests/StripTypeInfo.cs
+++ b/tests/trx2junit.Core.Tests/Internal/TypeInfoHelperTests/StripTypeInfo.cs
@@ -3,7 +3,7 @@
 using System.Collections.Generic;
 using NUnit.Framework;
 
-namespace gfoidl.Trx2Junit.Core.Tests.Extensions.StringExtensionsTests;
+namespace gfoidl.Trx2Junit.Core.Tests.Internal.TypeInfoHelperTests;
 
 [TestFixture]
 public class StripTypeInfo
@@ -19,13 +19,13 @@ public class StripTypeInfo
         yield return new TestCaseData(null).Returns(null);
         yield return new TestCaseData("").Returns("");
 
-        yield return new TestCaseData("Method1")                .Returns("Method1");
+        yield return new TestCaseData("Method1").Returns("Method1");
         yield return new TestCaseData("Method1(arg: { a = 3 })").Returns("Method1(arg: { a = 3 })");
 
-        yield return new TestCaseData("Class1.Method1")                .Returns("Method1");
+        yield return new TestCaseData("Class1.Method1").Returns("Method1");
         yield return new TestCaseData("Class1.Method1(arg: { a = 3 })").Returns("Method1(arg: { a = 3 })");
 
-        yield return new TestCaseData("SimpleUnitTest.Class1.Method1")                .Returns("Method1");
+        yield return new TestCaseData("SimpleUnitTest.Class1.Method1").Returns("Method1");
         yield return new TestCaseData("SimpleUnitTest.Class1.Method1(arg: { a = 3 })").Returns("Method1(arg: { a = 3 })");
     }
 }


### PR DESCRIPTION
Fixes https://github.com/gfoidl/trx2junit/issues/110

With https://github.com/gfoidl/trx2junit/pull/103 type information got stripped from the testcase name by searching for any `.` in it. If there are any arguments that contain a `.` (e.g. as decimal separater) then non-expected testcase names are produces.

This change preserves the content of arguments given a pair of parenthesis.
