### PR TITLE
Core-project can be used standalone, so respect potential use outside of trx2junit

### DIFF
--- a/source/trx2junit.Core/Internal/TestResultXmlConverter.cs
+++ b/source/trx2junit.Core/Internal/TestResultXmlConverter.cs
@@ -20,7 +20,7 @@ internal abstract class TestResultXmlConverter<TIn, TOut> : ITestResultXmlConver
     //-------------------------------------------------------------------------
     public virtual async Task ConvertAsync(Stream input, TextWriter output)
     {
-        XElement testXml = await XElement.LoadAsync(input, LoadOptions.None, CancellationToken.None);
+        XElement testXml = await XElement.LoadAsync(input, LoadOptions.None, CancellationToken.None).ConfigureAwait(false);
 
         ITestResultXmlParser<TIn> parser = this.ParserFactory(testXml);
         parser.Parse();
@@ -33,7 +33,7 @@ internal abstract class TestResultXmlConverter<TIn, TOut> : ITestResultXmlConver
         ITestResultXmlBuilder<TOut> builder = this.BuilderFactory(targetTest);
         builder.Build();
 
-        await builder.Result.SaveAsync(output, SaveOptions.None, CancellationToken.None);
+        await builder.Result.SaveAsync(output, SaveOptions.None, CancellationToken.None).ConfigureAwait(false);
     }
     //-------------------------------------------------------------------------
     public string GetOutputFile(string inputFile, string? outputPath = null)

--- a/source/trx2junit.Core/Worker.cs
+++ b/source/trx2junit.Core/Worker.cs
@@ -65,27 +65,37 @@ public class Worker
         if (options is null) throw new ArgumentNullException(nameof(options));
 #endif
 
+        CultureInfo currentThreadCulture      = Thread.CurrentThread.CurrentCulture;
+        CultureInfo currentUICulture          = Thread.CurrentThread.CurrentUICulture;
         Thread.CurrentThread.CurrentCulture   = CultureInfo.InvariantCulture;
         Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
 
-        _globHandler.ExpandWildcards(options);
-
-        ITestResultXmlConverter converter;
-
-        if (options.ConvertToJunit)
+        try
         {
-            converter = new Trx2JunitTestResultXmlConverter();
-            this.OnNotification($"Converting {options.InputFiles.Count} trx file(s) to JUnit-xml...");
-        }
-        else
-        {
-            converter = new Junit2TrxTestResultXmlConverter();
-            this.OnNotification($"Converting {options.InputFiles.Count} junit file(s) to trx-xml...");
-        }
-        DateTime start = DateTime.Now;
+            _globHandler.ExpandWildcards(options);
 
-        await Task.WhenAll(options.InputFiles.Select(input => this.ConvertAsync(converter, input, options.OutputDirectory)));
-        this.OnNotification($"done in {(DateTime.Now - start).TotalSeconds} seconds. bye.");
+            ITestResultXmlConverter converter;
+
+            if (options.ConvertToJunit)
+            {
+                converter = new Trx2JunitTestResultXmlConverter();
+                this.OnNotification($"Converting {options.InputFiles.Count} trx file(s) to JUnit-xml...");
+            }
+            else
+            {
+                converter = new Junit2TrxTestResultXmlConverter();
+                this.OnNotification($"Converting {options.InputFiles.Count} junit file(s) to trx-xml...");
+            }
+            DateTime start = DateTime.Now;
+
+            await Task.WhenAll(options.InputFiles.Select(input => this.ConvertAsync(converter, input, options.OutputDirectory)));
+            this.OnNotification($"done in {(DateTime.Now - start).TotalSeconds} seconds. bye.");
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentCulture   = currentThreadCulture;
+            Thread.CurrentThread.CurrentUICulture = currentUICulture;
+        }
     }
     //-------------------------------------------------------------------------
     // internal for testing

--- a/source/trx2junit.Core/Worker.cs
+++ b/source/trx2junit.Core/Worker.cs
@@ -88,7 +88,7 @@ public class Worker
             }
             DateTime start = DateTime.Now;
 
-            await Task.WhenAll(options.InputFiles.Select(input => this.ConvertAsync(converter, input, options.OutputDirectory)));
+            await Task.WhenAll(options.InputFiles.Select(input => this.ConvertAsync(converter, input, options.OutputDirectory))).ConfigureAwait(false);
             this.OnNotification($"done in {(DateTime.Now - start).TotalSeconds} seconds. bye.");
         }
         finally
@@ -111,7 +111,7 @@ public class Worker
 
         try
         {
-            await converter.ConvertAsync(input, output);
+            await converter.ConvertAsync(input, output).ConfigureAwait(false);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
* Restore thread culture after conversion
* Use ConfigureAwait(false)
